### PR TITLE
feat: datasource fallbacks

### DIFF
--- a/backstage/data_source_api.go
+++ b/backstage/data_source_api.go
@@ -245,6 +245,12 @@ func (d *apiDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		if state.Fallback.ID.IsNull() {
 			state.Fallback.ID = types.StringValue("123456789")
 		}
+		if state.Fallback.ApiVersion.IsNull() {
+			state.Fallback.ApiVersion = types.StringValue("backstage.io/v1alpha1")
+		}
+		if state.Fallback.Kind.IsNull() {
+			state.Fallback.Kind = types.StringValue(backstage.KindAPI)
+		}
 		state.ID = state.Fallback.ID
 		state.Name = state.Fallback.Name
 		state.Namespace = state.Fallback.Namespace
@@ -253,7 +259,6 @@ func (d *apiDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		state.Metadata = state.Fallback.Metadata
 		state.Relations = state.Fallback.Relations
 		state.Spec = state.Fallback.Spec
-		state.Fallback = nil
 	}
 	if err == nil && response.StatusCode == http.StatusOK {
 		state.ID = types.StringValue(api.Metadata.UID)

--- a/backstage/data_source_api.go
+++ b/backstage/data_source_api.go
@@ -72,7 +72,7 @@ const (
 	descriptionApiSpecOwner      = "An entity reference to the owner of the API"
 	descriptionApiSpecDefinition = "Definition of the API, based on the format defined by the type."
 	descriptionApiSpecSystem     = "An entity reference to the system that the API belongs to."
-	descriptionEntityFallback    = "A full entity object that represents the API as it would exist in backstage. Set this to provide a fallback in case the API is not functioning, is down, or is unrealiable."
+	descriptionApiFallback       = "A full entity object that represents the API as it would exist in backstage. Set this to provide a fallback in case the API is not functioning, is down, or is unrealiable."
 )
 
 // Schema defines the schema for the data source.
@@ -136,7 +136,7 @@ func (d *apiDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, re
 				"definition": schema.StringAttribute{Computed: true, Description: descriptionApiSpecDefinition},
 				"system":     schema.StringAttribute{Computed: true, Description: descriptionApiSpecSystem},
 			}},
-			"fallback": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityFallback, Attributes: map[string]schema.Attribute{
+			"fallback": schema.SingleNestedAttribute{Optional: true, Description: descriptionApiFallback, Attributes: map[string]schema.Attribute{
 				"id": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataUID},
 				"name": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataName, Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 63),

--- a/backstage/data_source_api.go
+++ b/backstage/data_source_api.go
@@ -72,7 +72,7 @@ const (
 	descriptionApiSpecOwner      = "An entity reference to the owner of the API"
 	descriptionApiSpecDefinition = "Definition of the API, based on the format defined by the type."
 	descriptionApiSpecSystem     = "An entity reference to the system that the API belongs to."
-	descriptionApiFallback       = "A full entity object that represents the API as it would exist in backstage. Set this to provide a fallback in case the API is not functioning, is down, or is unrealiable."
+	descriptionApiFallback       = "A complete replica of the `API` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable."
 )
 
 // Schema defines the schema for the data source.
@@ -137,60 +137,60 @@ func (d *apiDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, re
 				"system":     schema.StringAttribute{Computed: true, Description: descriptionApiSpecSystem},
 			}},
 			"fallback": schema.SingleNestedAttribute{Optional: true, Description: descriptionApiFallback, Attributes: map[string]schema.Attribute{
-				"id": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataUID},
-				"name": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataName, Validators: []validator.String{
+				"id": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+				"name": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataName, Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 63),
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(patternEntityName),
 						"must follow Backstage format restrictions",
 					),
 				}},
-				"namespace": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataNamespace, Validators: []validator.String{
+				"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace, Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 63),
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(patternEntityName),
 						"must follow Backstage format restrictions",
 					),
 				}},
-				"api_version": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityApiVersion},
-				"kind":        schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityKind},
-				"metadata": schema.SingleNestedAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadata, Attributes: map[string]schema.Attribute{
-					"uid":         schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataUID},
-					"etag":        schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataEtag},
-					"name":        schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataName},
-					"namespace":   schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataNamespace},
-					"title":       schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataTitle},
-					"description": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataDescription},
-					"labels":      schema.MapAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataLabels, ElementType: types.StringType},
-					"annotations": schema.MapAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataAnnotations, ElementType: types.StringType},
-					"tags":        schema.ListAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataTags, ElementType: types.StringType},
-					"links": schema.ListNestedAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataLinks, NestedObject: schema.NestedAttributeObject{
+				"api_version": schema.StringAttribute{Optional: true, Description: descriptionEntityApiVersion},
+				"kind":        schema.StringAttribute{Optional: true, Description: descriptionEntityKind},
+				"metadata": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityMetadata, Attributes: map[string]schema.Attribute{
+					"uid":         schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+					"etag":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataEtag},
+					"name":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataName},
+					"namespace":   schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace},
+					"title":       schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataTitle},
+					"description": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataDescription},
+					"labels":      schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataLabels, ElementType: types.StringType},
+					"annotations": schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataAnnotations, ElementType: types.StringType},
+					"tags":        schema.ListAttribute{Optional: true, Description: descriptionEntityMetadataTags, ElementType: types.StringType},
+					"links": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityMetadataLinks, NestedObject: schema.NestedAttributeObject{
 						Attributes: map[string]schema.Attribute{
-							"url":   schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityLinkURL},
-							"title": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityLinkTitle},
-							"icon":  schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityLinkIco},
-							"type":  schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityLinkType},
+							"url":   schema.StringAttribute{Optional: true, Description: descriptionEntityLinkURL},
+							"title": schema.StringAttribute{Optional: true, Description: descriptionEntityLinkTitle},
+							"icon":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkIco},
+							"type":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkType},
 						},
 					}},
 				}},
-				"relations": schema.ListNestedAttribute{Optional: true, Computed: true, Description: descriptionEntityRelations, NestedObject: schema.NestedAttributeObject{
+				"relations": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityRelations, NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"type":       schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityRelationType},
-						"target_ref": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityRelationTargetRef},
-						"target": schema.SingleNestedAttribute{Optional: true, Computed: true, Description: descriptionEntityRelationTarget,
+						"type":       schema.StringAttribute{Optional: true, Description: descriptionEntityRelationType},
+						"target_ref": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetRef},
+						"target": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityRelationTarget,
 							Attributes: map[string]schema.Attribute{
-								"name":      schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityRelationTargetName},
-								"kind":      schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityRelationTargetKind},
-								"namespace": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityRelationTargetNamespace},
+								"name":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetName},
+								"kind":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetKind},
+								"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetNamespace},
 							}},
 					},
 				}},
-				"spec": schema.SingleNestedAttribute{Optional: true, Computed: true, Description: descriptionEntitySpec, Attributes: map[string]schema.Attribute{
-					"type":       schema.StringAttribute{Optional: true, Computed: true, Description: descriptionApiSpecType},
-					"lifecycle":  schema.StringAttribute{Optional: true, Computed: true, Description: descriptionApiSpecLifecycle},
-					"owner":      schema.StringAttribute{Optional: true, Computed: true, Description: descriptionApiSpecOwner},
-					"definition": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionApiSpecDefinition},
-					"system":     schema.StringAttribute{Optional: true, Computed: true, Description: descriptionApiSpecSystem},
+				"spec": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntitySpec, Attributes: map[string]schema.Attribute{
+					"type":       schema.StringAttribute{Optional: true, Description: descriptionApiSpecType},
+					"lifecycle":  schema.StringAttribute{Optional: true, Description: descriptionApiSpecLifecycle},
+					"owner":      schema.StringAttribute{Optional: true, Description: descriptionApiSpecOwner},
+					"definition": schema.StringAttribute{Optional: true, Description: descriptionApiSpecDefinition},
+					"system":     schema.StringAttribute{Optional: true, Description: descriptionApiSpecSystem},
 				}},
 			}},
 		},
@@ -223,22 +223,22 @@ func (d *apiDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	api, response, err := d.client.Catalog.APIs.Get(ctx, state.Name.ValueString(), state.Namespace.ValueString())
 	if err != nil {
 		const shortErr = "Error reading Backstage API kind"
-		description := fmt.Sprintf("Could not read Backstage API kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error())
+		longErr := fmt.Sprintf("Could not read Backstage API kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error())
 		if state.Fallback == nil {
-			resp.Diagnostics.AddError(shortErr, description)
+			resp.Diagnostics.AddError(shortErr, longErr)
 			return
 		}
-		resp.Diagnostics.AddWarning(shortErr, description)
+		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 
 	if response.StatusCode != http.StatusOK {
 		const shortErr = "Error reading Backstage API kind"
-		description := fmt.Sprintf("Could not read Backstage API kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status)
+		longErr := fmt.Sprintf("Could not read Backstage API kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status)
 		if state.Fallback == nil {
-			resp.Diagnostics.AddError(shortErr, description)
+			resp.Diagnostics.AddError(shortErr, longErr)
 			return
 		}
-		resp.Diagnostics.AddWarning(shortErr, description)
+		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 	// Rebuild state from fallback when configured
 	if (err != nil || response.StatusCode != http.StatusOK) && state.Fallback != nil {

--- a/backstage/data_source_api.go
+++ b/backstage/data_source_api.go
@@ -242,6 +242,9 @@ func (d *apiDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	}
 	// Rebuild state from fallback when configured
 	if (err != nil || response.StatusCode != http.StatusOK) && state.Fallback != nil {
+		if state.Fallback.ID.IsNull() {
+			state.Fallback.ID = types.StringValue("123456789")
+		}
 		state.ID = state.Fallback.ID
 		state.Name = state.Fallback.Name
 		state.Namespace = state.Fallback.Namespace

--- a/backstage/data_source_api_test.go
+++ b/backstage/data_source_api_test.go
@@ -47,6 +47,11 @@ func TestAccApiDataSource_WithFallback(t *testing.T) {
 							id = "123456"
                             name = "fallback_api"
                             namespace = "default"
+							metadata = {
+								labels = {
+									"key" = "value"
+								}
+							}
                             spec = {
                                 type = "openapi"
                                 lifecycle = "production"
@@ -65,6 +70,7 @@ func TestAccApiDataSource_WithFallback(t *testing.T) {
 					resource.TestCheckResourceAttr("data.backstage_api.test", "spec.owner", "team-a"),
 					resource.TestCheckResourceAttr("data.backstage_api.test", "spec.definition", "https://example.com/api-spec"),
 					resource.TestCheckResourceAttr("data.backstage_api.test", "spec.system", "system-x"),
+					resource.TestCheckResourceAttr("data.backstage_api.test", "metadata.labels.key", "value"),
 				),
 			},
 		},

--- a/backstage/data_source_api_test.go
+++ b/backstage/data_source_api_test.go
@@ -41,7 +41,7 @@ func TestAccApiDataSource_WithFallback(t *testing.T) {
 			{
 				Config: `
                     data "backstage_api" "test" {
-                        name = "non_existent_api"
+                        name = "non_existent_api_a9ab8"
                         namespace = "default"
                         fallback = {
 							id = "123456"

--- a/backstage/data_source_api_test.go
+++ b/backstage/data_source_api_test.go
@@ -33,3 +33,40 @@ data "backstage_api" "test" {
   name = "streetlights"
 }
 `
+
+func TestAccApiDataSource_WithFallback(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+                    data "backstage_api" "test" {
+                        name = "non_existent_api"
+                        namespace = "default"
+                        fallback = {
+							id = "123456"
+                            name = "fallback_api"
+                            namespace = "default"
+                            spec = {
+                                type = "openapi"
+                                lifecycle = "production"
+                                owner = "team-a"
+                                definition = "https://example.com/api-spec"
+                                system = "system-x"
+                            }
+                        }
+                    }
+                `,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.backstage_api.test", "name", "fallback_api"),
+					resource.TestCheckResourceAttr("data.backstage_api.test", "namespace", "default"),
+					resource.TestCheckResourceAttr("data.backstage_api.test", "spec.type", "openapi"),
+					resource.TestCheckResourceAttr("data.backstage_api.test", "spec.lifecycle", "production"),
+					resource.TestCheckResourceAttr("data.backstage_api.test", "spec.owner", "team-a"),
+					resource.TestCheckResourceAttr("data.backstage_api.test", "spec.definition", "https://example.com/api-spec"),
+					resource.TestCheckResourceAttr("data.backstage_api.test", "spec.system", "system-x"),
+				),
+			},
+		},
+	})
+}

--- a/backstage/data_source_component.go
+++ b/backstage/data_source_component.go
@@ -31,14 +31,15 @@ type componentDataSource struct {
 }
 
 type componentDataSourceModel struct {
-	ID         types.String          `tfsdk:"id"`
-	Name       types.String          `tfsdk:"name"`
-	Namespace  types.String          `tfsdk:"namespace"`
-	ApiVersion types.String          `tfsdk:"api_version"`
-	Kind       types.String          `tfsdk:"kind"`
-	Metadata   *entityMetadataModel  `tfsdk:"metadata"`
-	Relations  []entityRelationModel `tfsdk:"relations"`
-	Spec       *componentSpecModel   `tfsdk:"spec"`
+	ID         types.String            `tfsdk:"id"`
+	Name       types.String            `tfsdk:"name"`
+	Namespace  types.String            `tfsdk:"namespace"`
+	ApiVersion types.String            `tfsdk:"api_version"`
+	Kind       types.String            `tfsdk:"kind"`
+	Metadata   *entityMetadataModel    `tfsdk:"metadata"`
+	Relations  []entityRelationModel   `tfsdk:"relations"`
+	Spec       *componentSpecModel     `tfsdk:"spec"`
+	Fallback   *componentFallbackModel `tfsdk:"fallback"`
 }
 
 type componentSpecModel struct {
@@ -52,6 +53,17 @@ type componentSpecModel struct {
 	System         types.String   `tfsdk:"system"`
 }
 
+type componentFallbackModel struct {
+	ID         types.String          `tfsdk:"id"`
+	Name       types.String          `tfsdk:"name"`
+	Namespace  types.String          `tfsdk:"namespace"`
+	ApiVersion types.String          `tfsdk:"api_version"`
+	Kind       types.String          `tfsdk:"kind"`
+	Metadata   *entityMetadataModel  `tfsdk:"metadata"`
+	Relations  []entityRelationModel `tfsdk:"relations"`
+	Spec       *componentSpecModel   `tfsdk:"spec"`
+}
+
 const (
 	descriptionComponentSpecType           = "Type of the component definition."
 	descriptionComponentSpecLifecycle      = "Lifecycle state of the component."
@@ -61,6 +73,7 @@ const (
 	descriptionComponentSpecConsumesAPIs   = "An array of entity references to the APIs that are consumed by the component."
 	descriptionComponentSpecDependsOn      = "An array of entity references to the components and resources that the component depends on."
 	descriptionComponentSpecSystem         = "An entity reference to the system that the component belongs to."
+	descriptionComponentFallback           = "A full entity object that represents the Component as it would exist in backstage. Set this to provide a fallback in case the Component is not functioning, is down, or is unrealiable."
 )
 
 // Metadata returns the data source type name.
@@ -132,6 +145,66 @@ func (d *componentDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 				"depends_on":      schema.ListAttribute{Computed: true, Description: descriptionComponentSpecDependsOn, ElementType: types.StringType},
 				"system":          schema.StringAttribute{Computed: true, Description: descriptionComponentSpecSystem},
 			}},
+			"fallback": schema.SingleNestedAttribute{Computed: true, Optional: true, Description: descriptionComponentFallback, Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataUID},
+				"name": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataName, Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 63),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(patternEntityName),
+						"must follow Backstage format restrictions",
+					),
+				}},
+				"namespace": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataNamespace, Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 63),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(patternEntityName),
+						"must follow Backstage format restrictions",
+					),
+				}},
+				"api_version": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityApiVersion},
+				"kind":        schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityKind},
+				"metadata": schema.SingleNestedAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadata, Attributes: map[string]schema.Attribute{
+					"uid":         schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataUID},
+					"etag":        schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataEtag},
+					"name":        schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataName},
+					"namespace":   schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataNamespace},
+					"title":       schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataTitle},
+					"description": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataDescription},
+					"labels":      schema.MapAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataLabels, ElementType: types.StringType},
+					"annotations": schema.MapAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataAnnotations, ElementType: types.StringType},
+					"tags":        schema.ListAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataTags, ElementType: types.StringType},
+					"links": schema.ListNestedAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataLinks, NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"url":   schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityLinkURL},
+							"title": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityLinkTitle},
+							"icon":  schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityLinkIco},
+							"type":  schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityLinkType},
+						},
+					}},
+				}},
+				"relations": schema.ListNestedAttribute{Computed: true, Optional: true, Description: descriptionEntityRelations, NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type":       schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationType},
+						"target_ref": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationTargetRef},
+						"target": schema.SingleNestedAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationTarget,
+							Attributes: map[string]schema.Attribute{
+								"name":      schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationTargetName},
+								"kind":      schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationTargetKind},
+								"namespace": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationTargetNamespace},
+							}},
+					},
+				}},
+				"spec": schema.SingleNestedAttribute{Computed: true, Optional: true, Description: descriptionEntitySpec, Attributes: map[string]schema.Attribute{
+					"type":            schema.StringAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecType},
+					"lifecycle":       schema.StringAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecLifecycle},
+					"owner":           schema.StringAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecOwner},
+					"subcomponent_of": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecSubcomponentOf},
+					"provides_apis":   schema.ListAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecProvidesAPIs, ElementType: types.StringType},
+					"consumes_apis":   schema.ListAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecConsumesAPIs, ElementType: types.StringType},
+					"depends_on":      schema.ListAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecDependsOn, ElementType: types.StringType},
+					"system":          schema.StringAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecSystem},
+				}},
+			}},
 		},
 	}
 }
@@ -161,86 +234,102 @@ func (d *componentDataSource) Read(ctx context.Context, req datasource.ReadReque
 	tflog.Debug(ctx, fmt.Sprintf("Getting Component kind %s/%s from Backstage API", state.Name.ValueString(), state.Namespace.ValueString()))
 	component, response, err := d.client.Catalog.Components.Get(ctx, state.Name.ValueString(), state.Namespace.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading Backstage Component kind",
-			fmt.Sprintf("Could not read Backstage Component kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error()),
-		)
-		return
+		const shortErr = "Error reading Backstage Component kind"
+		description := fmt.Sprintf("Could not read Backstage Component kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error())
+		if state.Fallback == nil {
+			resp.Diagnostics.AddError(shortErr, description)
+			return
+		}
+		resp.Diagnostics.AddWarning(shortErr, description)
 	}
 
 	if response.StatusCode != http.StatusOK {
-		resp.Diagnostics.AddError(
-			"Error reading Backstage Component kind",
-			fmt.Sprintf("Could not read Backstage Component kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status),
-		)
-		return
+		const shortErr = "Error reading Backstage Component kind"
+		description := fmt.Sprintf("Could not read Backstage Component kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status)
+		if state.Fallback == nil {
+			resp.Diagnostics.AddError(shortErr, description)
+			return
+		}
+		resp.Diagnostics.AddWarning(shortErr, description)
+	}
+	if (err != nil || response.StatusCode != http.StatusOK) && state.Fallback != nil {
+		state.ID = state.Fallback.ID
+		state.Name = state.Fallback.Name
+		state.Namespace = state.Fallback.Namespace
+		state.ApiVersion = state.Fallback.ApiVersion
+		state.Kind = state.Fallback.Kind
+		state.Metadata = state.Fallback.Metadata
+		state.Relations = state.Fallback.Relations
+		state.Spec = state.Fallback.Spec
 	}
 
-	state.ID = types.StringValue(component.Metadata.UID)
-	state.ApiVersion = types.StringValue(component.ApiVersion)
-	state.Kind = types.StringValue(component.Kind)
+	if err == nil && response.StatusCode == http.StatusOK {
+		state.ID = types.StringValue(component.Metadata.UID)
+		state.ApiVersion = types.StringValue(component.ApiVersion)
+		state.Kind = types.StringValue(component.Kind)
 
-	for _, i := range component.Relations {
-		state.Relations = append(state.Relations, entityRelationModel{
-			Type:      types.StringValue(i.Type),
-			TargetRef: types.StringValue(i.TargetRef),
-			Target: &entityRelationTargetModel{
-				Kind:      types.StringValue(i.Target.Kind),
-				Name:      types.StringValue(i.Target.Name),
-				Namespace: types.StringValue(i.Target.Namespace)},
-		})
-	}
+		for _, i := range component.Relations {
+			state.Relations = append(state.Relations, entityRelationModel{
+				Type:      types.StringValue(i.Type),
+				TargetRef: types.StringValue(i.TargetRef),
+				Target: &entityRelationTargetModel{
+					Kind:      types.StringValue(i.Target.Kind),
+					Name:      types.StringValue(i.Target.Name),
+					Namespace: types.StringValue(i.Target.Namespace)},
+			})
+		}
 
-	state.Spec = &componentSpecModel{
-		Type:           types.StringValue(component.Spec.Type),
-		Lifecycle:      types.StringValue(component.Spec.Lifecycle),
-		Owner:          types.StringValue(component.Spec.Owner),
-		SubcomponentOf: types.StringValue(component.Spec.SubcomponentOf),
-		System:         types.StringValue(component.Spec.System),
-	}
+		state.Spec = &componentSpecModel{
+			Type:           types.StringValue(component.Spec.Type),
+			Lifecycle:      types.StringValue(component.Spec.Lifecycle),
+			Owner:          types.StringValue(component.Spec.Owner),
+			SubcomponentOf: types.StringValue(component.Spec.SubcomponentOf),
+			System:         types.StringValue(component.Spec.System),
+		}
 
-	for _, i := range component.Spec.ProvidesApis {
-		state.Spec.ProvidesApis = append(state.Spec.ProvidesApis, types.StringValue(i))
-	}
+		for _, i := range component.Spec.ProvidesApis {
+			state.Spec.ProvidesApis = append(state.Spec.ProvidesApis, types.StringValue(i))
+		}
 
-	for _, i := range component.Spec.ConsumesApis {
-		state.Spec.ConsumesApis = append(state.Spec.ConsumesApis, types.StringValue(i))
-	}
+		for _, i := range component.Spec.ConsumesApis {
+			state.Spec.ConsumesApis = append(state.Spec.ConsumesApis, types.StringValue(i))
+		}
 
-	for _, i := range component.Spec.DependsOn {
-		state.Spec.DependsOn = append(state.Spec.DependsOn, types.StringValue(i))
-	}
+		for _, i := range component.Spec.DependsOn {
+			state.Spec.DependsOn = append(state.Spec.DependsOn, types.StringValue(i))
+		}
 
-	state.Metadata = &entityMetadataModel{
-		UID:         types.StringValue(component.Metadata.UID),
-		Etag:        types.StringValue(component.Metadata.Etag),
-		Name:        types.StringValue(component.Metadata.Name),
-		Namespace:   types.StringValue(component.Metadata.Namespace),
-		Title:       types.StringValue(component.Metadata.Title),
-		Description: types.StringValue(component.Metadata.Description),
-		Annotations: map[string]string{},
-		Labels:      map[string]string{},
-	}
+		state.Metadata = &entityMetadataModel{
+			UID:         types.StringValue(component.Metadata.UID),
+			Etag:        types.StringValue(component.Metadata.Etag),
+			Name:        types.StringValue(component.Metadata.Name),
+			Namespace:   types.StringValue(component.Metadata.Namespace),
+			Title:       types.StringValue(component.Metadata.Title),
+			Description: types.StringValue(component.Metadata.Description),
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		}
 
-	for k, v := range component.Metadata.Labels {
-		state.Metadata.Labels[k] = v
-	}
+		for k, v := range component.Metadata.Labels {
+			state.Metadata.Labels[k] = v
+		}
 
-	for k, v := range component.Metadata.Annotations {
-		state.Metadata.Annotations[k] = v
-	}
+		for k, v := range component.Metadata.Annotations {
+			state.Metadata.Annotations[k] = v
+		}
 
-	for _, v := range component.Metadata.Tags {
-		state.Metadata.Tags = append(state.Metadata.Tags, types.StringValue(v))
-	}
+		for _, v := range component.Metadata.Tags {
+			state.Metadata.Tags = append(state.Metadata.Tags, types.StringValue(v))
+		}
 
-	for _, v := range component.Metadata.Links {
-		state.Metadata.Links = append(state.Metadata.Links, entityLinkModel{
-			URL:   types.StringValue(v.URL),
-			Title: types.StringValue(v.Title),
-			Icon:  types.StringValue(v.Icon),
-			Type:  types.StringValue(v.Type),
-		})
+		for _, v := range component.Metadata.Links {
+			state.Metadata.Links = append(state.Metadata.Links, entityLinkModel{
+				URL:   types.StringValue(v.URL),
+				Title: types.StringValue(v.Title),
+				Icon:  types.StringValue(v.Icon),
+				Type:  types.StringValue(v.Type),
+			})
+		}
 	}
 
 	diags := resp.State.Set(ctx, state)

--- a/backstage/data_source_component.go
+++ b/backstage/data_source_component.go
@@ -253,6 +253,9 @@ func (d *componentDataSource) Read(ctx context.Context, req datasource.ReadReque
 		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 	if (err != nil || response.StatusCode != http.StatusOK) && state.Fallback != nil {
+		if state.Fallback.ID.IsNull() {
+			state.Fallback.ID = types.StringValue("123456789")
+		}
 		state.ID = state.Fallback.ID
 		state.Name = state.Fallback.Name
 		state.Namespace = state.Fallback.Namespace

--- a/backstage/data_source_component.go
+++ b/backstage/data_source_component.go
@@ -256,6 +256,12 @@ func (d *componentDataSource) Read(ctx context.Context, req datasource.ReadReque
 		if state.Fallback.ID.IsNull() {
 			state.Fallback.ID = types.StringValue("123456789")
 		}
+		if state.Fallback.ApiVersion.IsNull() {
+			state.Fallback.ApiVersion = types.StringValue("backstage.io/v1alpha1")
+		}
+		if state.Fallback.Kind.IsNull() {
+			state.Fallback.Kind = types.StringValue(backstage.KindComponent)
+		}
 		state.ID = state.Fallback.ID
 		state.Name = state.Fallback.Name
 		state.Namespace = state.Fallback.Namespace

--- a/backstage/data_source_component.go
+++ b/backstage/data_source_component.go
@@ -73,7 +73,7 @@ const (
 	descriptionComponentSpecConsumesAPIs   = "An array of entity references to the APIs that are consumed by the component."
 	descriptionComponentSpecDependsOn      = "An array of entity references to the components and resources that the component depends on."
 	descriptionComponentSpecSystem         = "An entity reference to the system that the component belongs to."
-	descriptionComponentFallback           = "A full entity object that represents the Component as it would exist in backstage. Set this to provide a fallback in case the Component is not functioning, is down, or is unrealiable."
+	descriptionComponentFallback           = "A complete replica of the `Component` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable."
 )
 
 // Metadata returns the data source type name.
@@ -145,64 +145,64 @@ func (d *componentDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 				"depends_on":      schema.ListAttribute{Computed: true, Description: descriptionComponentSpecDependsOn, ElementType: types.StringType},
 				"system":          schema.StringAttribute{Computed: true, Description: descriptionComponentSpecSystem},
 			}},
-			"fallback": schema.SingleNestedAttribute{Computed: true, Optional: true, Description: descriptionComponentFallback, Attributes: map[string]schema.Attribute{
-				"id": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataUID},
-				"name": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataName, Validators: []validator.String{
+			"fallback": schema.SingleNestedAttribute{Optional: true, Description: descriptionComponentFallback, Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+				"name": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataName, Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 63),
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(patternEntityName),
 						"must follow Backstage format restrictions",
 					),
 				}},
-				"namespace": schema.StringAttribute{Optional: true, Computed: true, Description: descriptionEntityMetadataNamespace, Validators: []validator.String{
+				"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace, Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 63),
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(patternEntityName),
 						"must follow Backstage format restrictions",
 					),
 				}},
-				"api_version": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityApiVersion},
-				"kind":        schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityKind},
-				"metadata": schema.SingleNestedAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadata, Attributes: map[string]schema.Attribute{
-					"uid":         schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataUID},
-					"etag":        schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataEtag},
-					"name":        schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataName},
-					"namespace":   schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataNamespace},
-					"title":       schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataTitle},
-					"description": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataDescription},
-					"labels":      schema.MapAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataLabels, ElementType: types.StringType},
-					"annotations": schema.MapAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataAnnotations, ElementType: types.StringType},
-					"tags":        schema.ListAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataTags, ElementType: types.StringType},
-					"links": schema.ListNestedAttribute{Computed: true, Optional: true, Description: descriptionEntityMetadataLinks, NestedObject: schema.NestedAttributeObject{
+				"api_version": schema.StringAttribute{Optional: true, Description: descriptionEntityApiVersion},
+				"kind":        schema.StringAttribute{Optional: true, Description: descriptionEntityKind},
+				"metadata": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityMetadata, Attributes: map[string]schema.Attribute{
+					"uid":         schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+					"etag":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataEtag},
+					"name":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataName},
+					"namespace":   schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace},
+					"title":       schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataTitle},
+					"description": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataDescription},
+					"labels":      schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataLabels, ElementType: types.StringType},
+					"annotations": schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataAnnotations, ElementType: types.StringType},
+					"tags":        schema.ListAttribute{Optional: true, Description: descriptionEntityMetadataTags, ElementType: types.StringType},
+					"links": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityMetadataLinks, NestedObject: schema.NestedAttributeObject{
 						Attributes: map[string]schema.Attribute{
-							"url":   schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityLinkURL},
-							"title": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityLinkTitle},
-							"icon":  schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityLinkIco},
-							"type":  schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityLinkType},
+							"url":   schema.StringAttribute{Optional: true, Description: descriptionEntityLinkURL},
+							"title": schema.StringAttribute{Optional: true, Description: descriptionEntityLinkTitle},
+							"icon":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkIco},
+							"type":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkType},
 						},
 					}},
 				}},
-				"relations": schema.ListNestedAttribute{Computed: true, Optional: true, Description: descriptionEntityRelations, NestedObject: schema.NestedAttributeObject{
+				"relations": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityRelations, NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"type":       schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationType},
-						"target_ref": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationTargetRef},
-						"target": schema.SingleNestedAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationTarget,
+						"type":       schema.StringAttribute{Optional: true, Description: descriptionEntityRelationType},
+						"target_ref": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetRef},
+						"target": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityRelationTarget,
 							Attributes: map[string]schema.Attribute{
-								"name":      schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationTargetName},
-								"kind":      schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationTargetKind},
-								"namespace": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionEntityRelationTargetNamespace},
+								"name":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetName},
+								"kind":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetKind},
+								"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetNamespace},
 							}},
 					},
 				}},
-				"spec": schema.SingleNestedAttribute{Computed: true, Optional: true, Description: descriptionEntitySpec, Attributes: map[string]schema.Attribute{
-					"type":            schema.StringAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecType},
-					"lifecycle":       schema.StringAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecLifecycle},
-					"owner":           schema.StringAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecOwner},
-					"subcomponent_of": schema.StringAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecSubcomponentOf},
-					"provides_apis":   schema.ListAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecProvidesAPIs, ElementType: types.StringType},
-					"consumes_apis":   schema.ListAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecConsumesAPIs, ElementType: types.StringType},
-					"depends_on":      schema.ListAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecDependsOn, ElementType: types.StringType},
-					"system":          schema.StringAttribute{Computed: true, Optional: true, Description: descriptionComponentSpecSystem},
+				"spec": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntitySpec, Attributes: map[string]schema.Attribute{
+					"type":            schema.StringAttribute{Optional: true, Description: descriptionComponentSpecType},
+					"lifecycle":       schema.StringAttribute{Optional: true, Description: descriptionComponentSpecLifecycle},
+					"owner":           schema.StringAttribute{Optional: true, Description: descriptionComponentSpecOwner},
+					"subcomponent_of": schema.StringAttribute{Optional: true, Description: descriptionComponentSpecSubcomponentOf},
+					"provides_apis":   schema.ListAttribute{Optional: true, Description: descriptionComponentSpecProvidesAPIs, ElementType: types.StringType},
+					"consumes_apis":   schema.ListAttribute{Optional: true, Description: descriptionComponentSpecConsumesAPIs, ElementType: types.StringType},
+					"depends_on":      schema.ListAttribute{Optional: true, Description: descriptionComponentSpecDependsOn, ElementType: types.StringType},
+					"system":          schema.StringAttribute{Optional: true, Description: descriptionComponentSpecSystem},
 				}},
 			}},
 		},
@@ -235,22 +235,22 @@ func (d *componentDataSource) Read(ctx context.Context, req datasource.ReadReque
 	component, response, err := d.client.Catalog.Components.Get(ctx, state.Name.ValueString(), state.Namespace.ValueString())
 	if err != nil {
 		const shortErr = "Error reading Backstage Component kind"
-		description := fmt.Sprintf("Could not read Backstage Component kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error())
+		longErr := fmt.Sprintf("Could not read Backstage Component kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error())
 		if state.Fallback == nil {
-			resp.Diagnostics.AddError(shortErr, description)
+			resp.Diagnostics.AddError(shortErr, longErr)
 			return
 		}
-		resp.Diagnostics.AddWarning(shortErr, description)
+		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 
 	if response.StatusCode != http.StatusOK {
 		const shortErr = "Error reading Backstage Component kind"
-		description := fmt.Sprintf("Could not read Backstage Component kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status)
+		longErr := fmt.Sprintf("Could not read Backstage Component kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status)
 		if state.Fallback == nil {
-			resp.Diagnostics.AddError(shortErr, description)
+			resp.Diagnostics.AddError(shortErr, longErr)
 			return
 		}
-		resp.Diagnostics.AddWarning(shortErr, description)
+		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 	if (err != nil || response.StatusCode != http.StatusOK) && state.Fallback != nil {
 		state.ID = state.Fallback.ID

--- a/backstage/data_source_component_test.go
+++ b/backstage/data_source_component_test.go
@@ -44,17 +44,16 @@ func TestAccDataSourceComponent_WithFallback(t *testing.T) {
 						namespace = "default"
 						fallback = {
 							id = "123456"
-							kind = "Component"
+							kind = "MyOwnComponent"
 							name = "fallback_component"
 							namespace = "default"
 						}
 					}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.backstage_component.test", "kind", "Component"),
+					resource.TestCheckResourceAttr("data.backstage_component.test", "kind", "MyOwnComponent"),
 					resource.TestCheckResourceAttr("data.backstage_component.test", "name", "fallback_component"),
-					resource.TestCheckNoResourceAttr("data.backstage_component.test", "api_version"),
-					resource.TestCheckNoResourceAttr("data.backstage_component.test", "api_version"),
+					resource.TestCheckResourceAttr("data.backstage_component.test", "api_version", "backstage.io/v1alpha1"),
 					resource.TestCheckNoResourceAttr("data.backstage_component.test", "metadata"),
 				),
 			},

--- a/backstage/data_source_component_test.go
+++ b/backstage/data_source_component_test.go
@@ -40,7 +40,7 @@ func TestAccDataSourceComponent_WithFallback(t *testing.T) {
 			{
 				Config: `
 					data "backstage_component" "test" {
-						name = "non_existent_component"
+						name = "non_existent_component_a9ab8"
 						namespace = "default"
 						fallback = {
 							id = "123456"

--- a/backstage/data_source_component_test.go
+++ b/backstage/data_source_component_test.go
@@ -32,3 +32,32 @@ data "backstage_component" "test" {
   name = "shuffle-api"
 }
 `
+
+func TestAccDataSourceComponent_WithFallback(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "backstage_component" "test" {
+						name = "non_existent_component"
+						namespace = "default"
+						fallback = {
+							id = "123456"
+							kind = "Component"
+							name = "fallback_component"
+							namespace = "default"
+						}
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.backstage_component.test", "kind", "Component"),
+					resource.TestCheckResourceAttr("data.backstage_component.test", "name", "fallback_component"),
+					resource.TestCheckNoResourceAttr("data.backstage_component.test", "api_version"),
+					resource.TestCheckNoResourceAttr("data.backstage_component.test", "api_version"),
+					resource.TestCheckNoResourceAttr("data.backstage_component.test", "metadata"),
+				),
+			},
+		},
+	})
+}

--- a/backstage/data_source_domain.go
+++ b/backstage/data_source_domain.go
@@ -39,6 +39,18 @@ type domainDataSourceModel struct {
 	Metadata   *entityMetadataModel  `tfsdk:"metadata"`
 	Relations  []entityRelationModel `tfsdk:"relations"`
 	Spec       *domainSpecModel      `tfsdk:"spec"`
+	Fallback   *domainFallbackModel  `tfsdk:"fallback"`
+}
+
+type domainFallbackModel struct {
+	ID         types.String          `tfsdk:"id"`
+	Name       types.String          `tfsdk:"name"`
+	Namespace  types.String          `tfsdk:"namespace"`
+	ApiVersion types.String          `tfsdk:"api_version"`
+	Kind       types.String          `tfsdk:"kind"`
+	Metadata   *entityMetadataModel  `tfsdk:"metadata"`
+	Relations  []entityRelationModel `tfsdk:"relations"`
+	Spec       *domainSpecModel      `tfsdk:"spec"`
 }
 
 type domainSpecModel struct {
@@ -47,6 +59,7 @@ type domainSpecModel struct {
 
 const (
 	descriptionDomainSpecOwner = "An entity reference to the owner of the domain."
+	descriptionDomainFallback  = "A complete replica of the `Domain` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable."
 )
 
 // Metadata returns the data source type name.
@@ -111,6 +124,59 @@ func (d *domainDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 			"spec": schema.SingleNestedAttribute{Computed: true, Description: descriptionEntitySpec, Attributes: map[string]schema.Attribute{
 				"owner": schema.StringAttribute{Computed: true, Description: descriptionDomainSpecOwner},
 			}},
+			"fallback": schema.SingleNestedAttribute{Optional: true, Description: descriptionDomainFallback, Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+				"name": schema.StringAttribute{Required: true, Description: descriptionEntityMetadataName, Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 63),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(patternEntityName),
+						"must follow Backstage format restrictions",
+					),
+				}},
+				"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace, Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 63),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(patternEntityName),
+						"must follow Backstage format restrictions",
+					),
+				}},
+				"api_version": schema.StringAttribute{Optional: true, Description: descriptionEntityApiVersion},
+				"kind":        schema.StringAttribute{Optional: true, Description: descriptionEntityKind},
+				"metadata": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityMetadata, Attributes: map[string]schema.Attribute{
+					"uid":         schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+					"etag":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataEtag},
+					"name":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataName},
+					"namespace":   schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace},
+					"title":       schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataTitle},
+					"description": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataDescription},
+					"labels":      schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataLabels, ElementType: types.StringType},
+					"annotations": schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataAnnotations, ElementType: types.StringType},
+					"tags":        schema.ListAttribute{Optional: true, Description: descriptionEntityMetadataTags, ElementType: types.StringType},
+					"links": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityMetadataLinks, NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"url":   schema.StringAttribute{Optional: true, Description: descriptionEntityLinkURL},
+							"title": schema.StringAttribute{Optional: true, Description: descriptionEntityLinkTitle},
+							"icon":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkIco},
+							"type":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkType},
+						},
+					}},
+				}},
+				"relations": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityRelations, NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type":       schema.StringAttribute{Optional: true, Description: descriptionEntityRelationType},
+						"target_ref": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetRef},
+						"target": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityRelationTarget,
+							Attributes: map[string]schema.Attribute{
+								"name":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetName},
+								"kind":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetKind},
+								"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetNamespace},
+							}},
+					},
+				}},
+				"spec": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntitySpec, Attributes: map[string]schema.Attribute{
+					"owner": schema.StringAttribute{Optional: true, Description: descriptionDomainSpecOwner},
+				}},
+			}},
 		},
 	}
 }
@@ -140,70 +206,87 @@ func (d *domainDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	tflog.Debug(ctx, fmt.Sprintf("Getting Domain kind %s/%s from Backstage API", state.Name.ValueString(), state.Namespace.ValueString()))
 	domain, response, err := d.client.Catalog.Domains.Get(ctx, state.Name.ValueString(), state.Namespace.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading Backstage Domain kind",
-			fmt.Sprintf("Could not read Backstage Domain kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error()),
-		)
-		return
+		const shortErr = "Error reading Backstage Domain kind"
+		longErr := fmt.Sprintf("Could not read Backstage Domain kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error())
+		if state.Fallback == nil {
+			resp.Diagnostics.AddError(shortErr, longErr)
+			return
+		}
+		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 
 	if response.StatusCode != http.StatusOK {
-		resp.Diagnostics.AddError(
-			"Error reading Backstage Domain kind",
-			fmt.Sprintf("Could not read Backstage Domain kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status),
-		)
-		return
+		const shortErr = "Error reading Backstage Domain kind"
+		longErr := fmt.Sprintf("Could not read Backstage Domain kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status)
+		if state.Fallback == nil {
+			resp.Diagnostics.AddError(shortErr, longErr)
+			return
+		}
+		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 
-	state.ID = types.StringValue(domain.Metadata.UID)
-	state.ApiVersion = types.StringValue(domain.ApiVersion)
-	state.Kind = types.StringValue(domain.Kind)
-
-	for _, i := range domain.Relations {
-		state.Relations = append(state.Relations, entityRelationModel{
-			Type:      types.StringValue(i.Type),
-			TargetRef: types.StringValue(i.TargetRef),
-			Target: &entityRelationTargetModel{
-				Kind:      types.StringValue(i.Target.Kind),
-				Name:      types.StringValue(i.Target.Name),
-				Namespace: types.StringValue(i.Target.Namespace)},
-		})
+	if (err != nil || response.StatusCode != http.StatusOK) && state.Fallback != nil {
+		state.ID = state.Fallback.ID
+		state.Name = state.Fallback.Name
+		state.Namespace = state.Fallback.Namespace
+		state.ApiVersion = state.Fallback.ApiVersion
+		state.Kind = state.Fallback.Kind
+		state.Metadata = state.Fallback.Metadata
+		state.Relations = state.Fallback.Relations
+		state.Spec = state.Fallback.Spec
 	}
 
-	state.Spec = &domainSpecModel{
-		Owner: types.StringValue(domain.Spec.Owner),
-	}
+	if err == nil && response.StatusCode == http.StatusOK {
+		state.ID = types.StringValue(domain.Metadata.UID)
+		state.ApiVersion = types.StringValue(domain.ApiVersion)
+		state.Kind = types.StringValue(domain.Kind)
 
-	state.Metadata = &entityMetadataModel{
-		UID:         types.StringValue(domain.Metadata.UID),
-		Etag:        types.StringValue(domain.Metadata.Etag),
-		Name:        types.StringValue(domain.Metadata.Name),
-		Namespace:   types.StringValue(domain.Metadata.Namespace),
-		Title:       types.StringValue(domain.Metadata.Title),
-		Description: types.StringValue(domain.Metadata.Description),
-		Annotations: map[string]string{},
-		Labels:      map[string]string{},
-	}
+		for _, i := range domain.Relations {
+			state.Relations = append(state.Relations, entityRelationModel{
+				Type:      types.StringValue(i.Type),
+				TargetRef: types.StringValue(i.TargetRef),
+				Target: &entityRelationTargetModel{
+					Kind:      types.StringValue(i.Target.Kind),
+					Name:      types.StringValue(i.Target.Name),
+					Namespace: types.StringValue(i.Target.Namespace)},
+			})
+		}
 
-	for k, v := range domain.Metadata.Labels {
-		state.Metadata.Labels[k] = v
-	}
+		state.Spec = &domainSpecModel{
+			Owner: types.StringValue(domain.Spec.Owner),
+		}
 
-	for k, v := range domain.Metadata.Annotations {
-		state.Metadata.Annotations[k] = v
-	}
+		state.Metadata = &entityMetadataModel{
+			UID:         types.StringValue(domain.Metadata.UID),
+			Etag:        types.StringValue(domain.Metadata.Etag),
+			Name:        types.StringValue(domain.Metadata.Name),
+			Namespace:   types.StringValue(domain.Metadata.Namespace),
+			Title:       types.StringValue(domain.Metadata.Title),
+			Description: types.StringValue(domain.Metadata.Description),
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		}
 
-	for _, v := range domain.Metadata.Tags {
-		state.Metadata.Tags = append(state.Metadata.Tags, types.StringValue(v))
-	}
+		for k, v := range domain.Metadata.Labels {
+			state.Metadata.Labels[k] = v
+		}
 
-	for _, v := range domain.Metadata.Links {
-		state.Metadata.Links = append(state.Metadata.Links, entityLinkModel{
-			URL:   types.StringValue(v.URL),
-			Title: types.StringValue(v.Title),
-			Icon:  types.StringValue(v.Icon),
-			Type:  types.StringValue(v.Type),
-		})
+		for k, v := range domain.Metadata.Annotations {
+			state.Metadata.Annotations[k] = v
+		}
+
+		for _, v := range domain.Metadata.Tags {
+			state.Metadata.Tags = append(state.Metadata.Tags, types.StringValue(v))
+		}
+
+		for _, v := range domain.Metadata.Links {
+			state.Metadata.Links = append(state.Metadata.Links, entityLinkModel{
+				URL:   types.StringValue(v.URL),
+				Title: types.StringValue(v.Title),
+				Icon:  types.StringValue(v.Icon),
+				Type:  types.StringValue(v.Type),
+			})
+		}
 	}
 
 	diags := resp.State.Set(ctx, state)

--- a/backstage/data_source_domain.go
+++ b/backstage/data_source_domain.go
@@ -226,6 +226,9 @@ func (d *domainDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	if (err != nil || response.StatusCode != http.StatusOK) && state.Fallback != nil {
+		if state.Fallback.ID.IsNull() {
+			state.Fallback.ID = types.StringValue("123456789")
+		}
 		state.ID = state.Fallback.ID
 		state.Name = state.Fallback.Name
 		state.Namespace = state.Fallback.Namespace

--- a/backstage/data_source_domain.go
+++ b/backstage/data_source_domain.go
@@ -229,6 +229,12 @@ func (d *domainDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		if state.Fallback.ID.IsNull() {
 			state.Fallback.ID = types.StringValue("123456789")
 		}
+		if state.Fallback.ApiVersion.IsNull() {
+			state.Fallback.ApiVersion = types.StringValue("backstage.io/v1alpha1")
+		}
+		if state.Fallback.Kind.IsNull() {
+			state.Fallback.Kind = types.StringValue(backstage.KindDomain)
+		}
 		state.ID = state.Fallback.ID
 		state.Name = state.Fallback.Name
 		state.Namespace = state.Fallback.Namespace

--- a/backstage/data_source_domain_test.go
+++ b/backstage/data_source_domain_test.go
@@ -31,3 +31,36 @@ data "backstage_domain" "test" {
   name = "artists"
 }
 `
+
+func TestAccDataSourceDomain_WithFallback(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "backstage_domain" "test" {
+						name = "non_existent_domain"
+						namespace = "default"
+						fallback = {
+							id = "123456"
+							name = "fallback_domain"
+							kind = "Domain"
+							namespace = "fallback_default"
+							spec = {
+								owner = "team-a"
+							}
+						}
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.backstage_domain.test", "kind", "Domain"),
+					resource.TestCheckResourceAttr("data.backstage_domain.test", "spec.owner", "team-a"),
+					resource.TestCheckResourceAttr("data.backstage_domain.test", "name", "fallback_domain"),
+					resource.TestCheckResourceAttr("data.backstage_domain.test", "namespace", "fallback_default"),
+					resource.TestCheckNoResourceAttr("data.backstage_domain.test", "metadata"),
+					resource.TestCheckNoResourceAttr("data.backstage_domain.test", "relations"),
+				),
+			},
+		},
+	})
+}

--- a/backstage/data_source_domain_test.go
+++ b/backstage/data_source_domain_test.go
@@ -39,7 +39,7 @@ func TestAccDataSourceDomain_WithFallback(t *testing.T) {
 			{
 				Config: `
 					data "backstage_domain" "test" {
-						name = "non_existent_domain"
+						name = "non_existent_domain_a9ab8"
 						namespace = "default"
 						fallback = {
 							id = "123456"

--- a/backstage/data_source_entities.go
+++ b/backstage/data_source_entities.go
@@ -260,6 +260,9 @@ func (d *entityDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 	if (err != nil || response.StatusCode != http.StatusOK) && state.Fallback != nil {
+		if state.Fallback.ID.IsNull() {
+			state.Fallback.ID = types.StringValue("123456789")
+		}
 		state.ID = state.Fallback.ID
 		state.Filters = state.Fallback.Filters
 		state.Entities = state.Fallback.Entities

--- a/backstage/data_source_entities_test.go
+++ b/backstage/data_source_entities_test.go
@@ -2,9 +2,10 @@ package backstage
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/go-cty/cty/function/stdlib"
-	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/backstage/data_source_group.go
+++ b/backstage/data_source_group.go
@@ -261,6 +261,12 @@ func (d *groupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		if state.Fallback.ID.IsNull() {
 			state.Fallback.ID = types.StringValue("123456789")
 		}
+		if state.Fallback.ApiVersion.IsNull() {
+			state.Fallback.ApiVersion = types.StringValue("backstage.io/v1alpha1")
+		}
+		if state.Fallback.Kind.IsNull() {
+			state.Fallback.Kind = types.StringValue(backstage.KindGroup)
+		}
 		state.ID = state.Fallback.ID
 		state.Name = state.Fallback.Name
 		state.Namespace = state.Fallback.Namespace

--- a/backstage/data_source_group.go
+++ b/backstage/data_source_group.go
@@ -39,6 +39,7 @@ type groupDataSourceModel struct {
 	Metadata   *entityMetadataModel  `tfsdk:"metadata"`
 	Relations  []entityRelationModel `tfsdk:"relations"`
 	Spec       *groupSpecModel       `tfsdk:"spec"`
+	Fallback   *groupFallbackModel   `tfsdk:"fallback"`
 }
 
 type groupSpecModel struct {
@@ -55,6 +56,17 @@ type groupSpecProfileModel struct {
 	Picture     types.String `tfsdk:"picture"`
 }
 
+type groupFallbackModel struct {
+	ID         types.String          `tfsdk:"id"`
+	Name       types.String          `tfsdk:"name"`
+	Namespace  types.String          `tfsdk:"namespace"`
+	ApiVersion types.String          `tfsdk:"api_version"`
+	Kind       types.String          `tfsdk:"kind"`
+	Metadata   *entityMetadataModel  `tfsdk:"metadata"`
+	Relations  []entityRelationModel `tfsdk:"relations"`
+	Spec       *groupSpecModel       `tfsdk:"spec"`
+}
+
 const (
 	descriptionGroupType                   = "The type of group."
 	descriptionGroupSpecProfile            = "Profile information about the group, mainly for display purposes."
@@ -64,6 +76,7 @@ const (
 	descriptionGroupSpecParent             = "Parent is the immediate parent group in the hierarchy, if any."
 	descriptionGroupSpecChildren           = "Children contains immediate child groups of this group in the hierarchy (whose parent field points to this group)."
 	descriptionGroupSpecMembers            = "Members contains the users that are members of this group."
+	descriptionGroupFallback               = "A complete replica of the `Group` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable."
 )
 
 // Metadata returns the data source type name.
@@ -136,6 +149,67 @@ func (d *groupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 					"picture":      schema.StringAttribute{Computed: true, Description: descriptionGroupSpecProfilePicture},
 				}},
 			}},
+			"fallback": schema.SingleNestedAttribute{Optional: true, Description: descriptionGroupFallback, Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+				"name": schema.StringAttribute{Required: true, Description: descriptionEntityMetadataName, Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 63),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(patternEntityName),
+						"must follow Backstage format restrictions",
+					),
+				}},
+				"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace, Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 63),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(patternEntityName),
+						"must follow Backstage format restrictions",
+					),
+				}},
+				"api_version": schema.StringAttribute{Optional: true, Description: descriptionEntityApiVersion},
+				"kind":        schema.StringAttribute{Optional: true, Description: descriptionEntityKind},
+				"metadata": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityMetadata, Attributes: map[string]schema.Attribute{
+					"uid":         schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+					"etag":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataEtag},
+					"name":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataName},
+					"namespace":   schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace},
+					"title":       schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataTitle},
+					"description": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataDescription},
+					"labels":      schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataLabels, ElementType: types.StringType},
+					"annotations": schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataAnnotations, ElementType: types.StringType},
+					"tags":        schema.ListAttribute{Optional: true, Description: descriptionEntityMetadataTags, ElementType: types.StringType},
+					"links": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityMetadataLinks, NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"url":   schema.StringAttribute{Optional: true, Description: descriptionEntityLinkURL},
+							"title": schema.StringAttribute{Optional: true, Description: descriptionEntityLinkTitle},
+							"icon":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkIco},
+							"type":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkType},
+						},
+					}},
+				}},
+				"relations": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityRelations, NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type":       schema.StringAttribute{Optional: true, Description: descriptionEntityRelationType},
+						"target_ref": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetRef},
+						"target": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityRelationTarget,
+							Attributes: map[string]schema.Attribute{
+								"name":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetName},
+								"kind":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetKind},
+								"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetNamespace},
+							}},
+					},
+				}},
+				"spec": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntitySpec, Attributes: map[string]schema.Attribute{
+					"type":     schema.StringAttribute{Optional: true, Description: descriptionGroupType},
+					"parent":   schema.StringAttribute{Optional: true, Description: descriptionGroupSpecParent},
+					"children": schema.ListAttribute{Optional: true, Description: descriptionGroupSpecChildren, ElementType: types.StringType},
+					"members":  schema.ListAttribute{Optional: true, Description: descriptionGroupSpecMembers, ElementType: types.StringType},
+					"profile": schema.SingleNestedAttribute{Optional: true, Description: descriptionGroupSpecProfile, Attributes: map[string]schema.Attribute{
+						"display_name": schema.StringAttribute{Optional: true, Description: descriptionGroupSpecProfileDisplayName},
+						"email":        schema.StringAttribute{Optional: true, Description: descriptionGroupSpecProfileEmail},
+						"picture":      schema.StringAttribute{Optional: true, Description: descriptionGroupSpecProfilePicture},
+					}},
+				}},
+			}},
 		},
 	}
 }
@@ -165,84 +239,104 @@ func (d *groupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	tflog.Debug(ctx, fmt.Sprintf("Getting Group kind %s/%s from Backstage API", state.Name.ValueString(), state.Namespace.ValueString()))
 	group, response, err := d.client.Catalog.Groups.Get(ctx, state.Name.ValueString(), state.Namespace.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading Backstage Group kind",
-			fmt.Sprintf("Could not read Backstage Group kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error()),
-		)
-		return
+		const shortErr = "Error reading Backstage Group kind"
+		longErr := fmt.Sprintf("Could not read Backstage Group kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error())
+		if state.Fallback == nil {
+			resp.Diagnostics.AddError(shortErr, longErr)
+			return
+		}
+		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 
 	if response.StatusCode != http.StatusOK {
-		resp.Diagnostics.AddError(
-			"Error reading Backstage Group kind",
-			fmt.Sprintf("Could not read Backstage Group kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status),
-		)
-		return
+		const shortErr = "Error reading Backstage Group kind"
+		longErr := fmt.Sprintf("Could not read Backstage Group kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status)
+		if state.Fallback == nil {
+			resp.Diagnostics.AddError(shortErr, longErr)
+			return
+		}
+		resp.Diagnostics.AddWarning(shortErr, longErr)
+	}
+	if (err != nil || response.StatusCode != http.StatusOK) && state.Fallback != nil {
+		if state.Fallback.ID.IsNull() {
+			state.Fallback.ID = types.StringValue("123456789")
+		}
+		state.ID = state.Fallback.ID
+		state.Name = state.Fallback.Name
+		state.Namespace = state.Fallback.Namespace
+		state.ApiVersion = state.Fallback.ApiVersion
+		state.Kind = state.Fallback.Kind
+		state.Metadata = state.Fallback.Metadata
+		state.Relations = state.Fallback.Relations
+		state.Spec = state.Fallback.Spec
 	}
 
-	state.ID = types.StringValue(group.Metadata.UID)
-	state.ApiVersion = types.StringValue(group.ApiVersion)
-	state.Kind = types.StringValue(group.Kind)
+	if err == nil && response.StatusCode == http.StatusOK {
 
-	for _, i := range group.Relations {
-		state.Relations = append(state.Relations, entityRelationModel{
-			Type:      types.StringValue(i.Type),
-			TargetRef: types.StringValue(i.TargetRef),
-			Target: &entityRelationTargetModel{
-				Kind:      types.StringValue(i.Target.Kind),
-				Name:      types.StringValue(i.Target.Name),
-				Namespace: types.StringValue(i.Target.Namespace)},
-		})
-	}
+		state.ID = types.StringValue(group.Metadata.UID)
+		state.ApiVersion = types.StringValue(group.ApiVersion)
+		state.Kind = types.StringValue(group.Kind)
 
-	state.Spec = &groupSpecModel{
-		Type:   types.StringValue(group.Spec.Type),
-		Parent: types.StringValue(group.Spec.Parent),
-		Profile: &groupSpecProfileModel{
-			DisplayName: types.StringValue(group.Spec.Profile.DisplayName),
-			Email:       types.StringValue(group.Spec.Profile.Email),
-			Picture:     types.StringValue(group.Spec.Profile.Picture),
-		},
-	}
+		for _, i := range group.Relations {
+			state.Relations = append(state.Relations, entityRelationModel{
+				Type:      types.StringValue(i.Type),
+				TargetRef: types.StringValue(i.TargetRef),
+				Target: &entityRelationTargetModel{
+					Kind:      types.StringValue(i.Target.Kind),
+					Name:      types.StringValue(i.Target.Name),
+					Namespace: types.StringValue(i.Target.Namespace)},
+			})
+		}
 
-	for _, i := range group.Spec.Children {
-		state.Spec.Children = append(state.Spec.Children, types.StringValue(i))
-	}
+		state.Spec = &groupSpecModel{
+			Type:   types.StringValue(group.Spec.Type),
+			Parent: types.StringValue(group.Spec.Parent),
+			Profile: &groupSpecProfileModel{
+				DisplayName: types.StringValue(group.Spec.Profile.DisplayName),
+				Email:       types.StringValue(group.Spec.Profile.Email),
+				Picture:     types.StringValue(group.Spec.Profile.Picture),
+			},
+		}
 
-	for _, i := range group.Spec.Members {
-		state.Spec.Members = append(state.Spec.Members, types.StringValue(i))
-	}
+		for _, i := range group.Spec.Children {
+			state.Spec.Children = append(state.Spec.Children, types.StringValue(i))
+		}
 
-	state.Metadata = &entityMetadataModel{
-		UID:         types.StringValue(group.Metadata.UID),
-		Etag:        types.StringValue(group.Metadata.Etag),
-		Name:        types.StringValue(group.Metadata.Name),
-		Namespace:   types.StringValue(group.Metadata.Namespace),
-		Title:       types.StringValue(group.Metadata.Title),
-		Description: types.StringValue(group.Metadata.Description),
-		Annotations: map[string]string{},
-		Labels:      map[string]string{},
-	}
+		for _, i := range group.Spec.Members {
+			state.Spec.Members = append(state.Spec.Members, types.StringValue(i))
+		}
 
-	for k, v := range group.Metadata.Labels {
-		state.Metadata.Labels[k] = v
-	}
+		state.Metadata = &entityMetadataModel{
+			UID:         types.StringValue(group.Metadata.UID),
+			Etag:        types.StringValue(group.Metadata.Etag),
+			Name:        types.StringValue(group.Metadata.Name),
+			Namespace:   types.StringValue(group.Metadata.Namespace),
+			Title:       types.StringValue(group.Metadata.Title),
+			Description: types.StringValue(group.Metadata.Description),
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		}
 
-	for k, v := range group.Metadata.Annotations {
-		state.Metadata.Annotations[k] = v
-	}
+		for k, v := range group.Metadata.Labels {
+			state.Metadata.Labels[k] = v
+		}
 
-	for _, v := range group.Metadata.Tags {
-		state.Metadata.Tags = append(state.Metadata.Tags, types.StringValue(v))
-	}
+		for k, v := range group.Metadata.Annotations {
+			state.Metadata.Annotations[k] = v
+		}
 
-	for _, v := range group.Metadata.Links {
-		state.Metadata.Links = append(state.Metadata.Links, entityLinkModel{
-			URL:   types.StringValue(v.URL),
-			Title: types.StringValue(v.Title),
-			Icon:  types.StringValue(v.Icon),
-			Type:  types.StringValue(v.Type),
-		})
+		for _, v := range group.Metadata.Tags {
+			state.Metadata.Tags = append(state.Metadata.Tags, types.StringValue(v))
+		}
+
+		for _, v := range group.Metadata.Links {
+			state.Metadata.Links = append(state.Metadata.Links, entityLinkModel{
+				URL:   types.StringValue(v.URL),
+				Title: types.StringValue(v.Title),
+				Icon:  types.StringValue(v.Icon),
+				Type:  types.StringValue(v.Type),
+			})
+		}
 	}
 
 	diags := resp.State.Set(ctx, state)

--- a/backstage/data_source_group_test.go
+++ b/backstage/data_source_group_test.go
@@ -31,3 +31,48 @@ data "backstage_group" "test" {
   name = "team-a"
 }
 `
+
+func TestAccDataSourceGroup_WithFallback(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "backstage_group" "test" {
+						name = "team_does_not_compute_a9ab8"
+						fallback = {
+							api_version = "backstage.io/v1alpha1"
+							name = "fallback_team"
+							kind = "Group"
+							metadata = {
+								description = "Fallback Team A"
+								annotations = {
+									"backstage.io/source-location" = "url:fallback.com"
+								}
+							}
+							spec = {
+								parent = "backstage"
+							}
+							relations = [
+								{
+									type = "childOf"
+									target_ref = "backstage"
+								}
+							]
+						}
+					}	
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.backstage_group.test", "api_version", "backstage.io/v1alpha1"),
+					resource.TestCheckResourceAttr("data.backstage_group.test", "kind", "Group"),
+					resource.TestCheckResourceAttr("data.backstage_group.test", "metadata.description", "Fallback Team A"),
+					resource.TestCheckResourceAttr("data.backstage_group.test", "metadata.annotations.backstage.io/source-location",
+						"url:fallback.com"),
+					resource.TestCheckResourceAttr("data.backstage_group.test", "relations.0.type", "childOf"),
+					resource.TestCheckResourceAttr("data.backstage_group.test", "spec.parent", "backstage"),
+					resource.TestCheckResourceAttr("data.backstage_group.test", "name", "fallback_team"),
+				),
+			},
+		},
+	})
+}

--- a/backstage/data_source_location.go
+++ b/backstage/data_source_location.go
@@ -153,7 +153,7 @@ func (d *locationDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 					),
 				}},
 				"api_version": schema.StringAttribute{Optional: true, Description: descriptionEntityApiVersion},
-				"kind":        schema.StringAttribute{Computed: true, Description: descriptionEntityKind},
+				"kind":        schema.StringAttribute{Optional: true, Description: descriptionEntityKind},
 				"metadata": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityMetadata, Attributes: map[string]schema.Attribute{
 					"uid":         schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
 					"etag":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataEtag},

--- a/backstage/data_source_location_test.go
+++ b/backstage/data_source_location_test.go
@@ -30,3 +30,35 @@ data "backstage_location" "test" {
   name = "example-components"
 }
 `
+
+func TestAccDataSourceLocation_WithFallback(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "backstage_location" "test" {
+						name = "non_existent_location_a9ab8"
+						namespace = "default"
+						fallback = {
+							name = "fallback_location"
+							namespace = "default"
+							metadata = {
+								description = "Fallback Location"
+							}
+							spec = {
+								targets = ["./components/artist-lookup-component.yaml"]
+							}
+						}
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.backstage_location.test", "api_version", "backstage.io/v1alpha1"),
+					resource.TestCheckResourceAttr("data.backstage_location.test", "kind", "Location"),
+					resource.TestCheckResourceAttr("data.backstage_location.test", "metadata.description", "Fallback Location"),
+					resource.TestCheckResourceAttr("data.backstage_location.test", "name", "fallback_location"),
+					resource.TestCheckResourceAttr("data.backstage_location.test", "spec.targets.0", "./components/artist-lookup-component.yaml"),
+				)},
+		},
+	})
+}

--- a/backstage/data_source_resource.go
+++ b/backstage/data_source_resource.go
@@ -31,6 +31,25 @@ type resourceDataSource struct {
 }
 
 type resourceDataSourceModel struct {
+	ID         types.String           `tfsdk:"id"`
+	Name       types.String           `tfsdk:"name"`
+	Namespace  types.String           `tfsdk:"namespace"`
+	ApiVersion types.String           `tfsdk:"api_version"`
+	Kind       types.String           `tfsdk:"kind"`
+	Metadata   *entityMetadataModel   `tfsdk:"metadata"`
+	Relations  []entityRelationModel  `tfsdk:"relations"`
+	Spec       *resourceSpecModel     `tfsdk:"spec"`
+	Fallback   *resourceFallbackModel `tfsdk:"fallback"`
+}
+
+type resourceSpecModel struct {
+	Type      types.String   `tfsdk:"type"`
+	Owner     types.String   `tfsdk:"owner"`
+	DependsOn []types.String `tfsdk:"depends_on"`
+	System    types.String   `tfsdk:"system"`
+}
+
+type resourceFallbackModel struct {
 	ID         types.String          `tfsdk:"id"`
 	Name       types.String          `tfsdk:"name"`
 	Namespace  types.String          `tfsdk:"namespace"`
@@ -41,18 +60,12 @@ type resourceDataSourceModel struct {
 	Spec       *resourceSpecModel    `tfsdk:"spec"`
 }
 
-type resourceSpecModel struct {
-	Type      types.String   `tfsdk:"type"`
-	Owner     types.String   `tfsdk:"owner"`
-	DependsOn []types.String `tfsdk:"depends_on"`
-	System    types.String   `tfsdk:"system"`
-}
-
 const (
 	descriptionResourceSpecType      = "Type of the resource definition."
 	descriptionResourceSpecOwner     = "An entity reference to the owner of the resource"
 	descriptionResourceSpecDependsOn = "An array of references to other entities that the resource depends on to function."
 	descriptionResourceSpecSystem    = "An entity reference to the system that the resource belongs to."
+	descriptionResourceFallback      = "A complete replica of the `Resource` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable."
 )
 
 // Metadata returns the data source type name.
@@ -120,6 +133,62 @@ func (d *resourceDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 				"depends_on": schema.ListAttribute{Computed: true, Description: descriptionResourceSpecDependsOn, ElementType: types.StringType},
 				"system":     schema.StringAttribute{Computed: true, Description: descriptionResourceSpecSystem},
 			}},
+			"fallback": schema.SingleNestedAttribute{Optional: true, Description: descriptionResourceFallback, Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+				"name": schema.StringAttribute{Required: true, Description: descriptionEntityMetadataName, Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 63),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(patternEntityName),
+						"must follow Backstage format restrictions",
+					),
+				}},
+				"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace, Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 63),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(patternEntityName),
+						"must follow Backstage format restrictions",
+					),
+				}},
+				"api_version": schema.StringAttribute{Optional: true, Description: descriptionEntityApiVersion},
+				"kind":        schema.StringAttribute{Optional: true, Description: descriptionEntityKind},
+				"metadata": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityMetadata, Attributes: map[string]schema.Attribute{
+					"uid":         schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+					"etag":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataEtag},
+					"name":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataName},
+					"namespace":   schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace},
+					"title":       schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataTitle},
+					"description": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataDescription},
+					"labels":      schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataLabels, ElementType: types.StringType},
+					"annotations": schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataAnnotations, ElementType: types.StringType},
+					"tags":        schema.ListAttribute{Optional: true, Description: descriptionEntityMetadataTags, ElementType: types.StringType},
+					"links": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityMetadataLinks, NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"url":   schema.StringAttribute{Optional: true, Description: descriptionEntityLinkURL},
+							"title": schema.StringAttribute{Optional: true, Description: descriptionEntityLinkTitle},
+							"icon":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkIco},
+							"type":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkType},
+						},
+					}},
+				}},
+				"relations": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityRelations, NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type":       schema.StringAttribute{Optional: true, Description: descriptionEntityRelationType},
+						"target_ref": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetRef},
+						"target": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityRelationTarget,
+							Attributes: map[string]schema.Attribute{
+								"name":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetName},
+								"kind":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetKind},
+								"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetNamespace},
+							}},
+					},
+				}},
+				"spec": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntitySpec, Attributes: map[string]schema.Attribute{
+					"type":       schema.StringAttribute{Optional: true, Description: descriptionResourceSpecType},
+					"owner":      schema.StringAttribute{Optional: true, Description: descriptionResourceSpecOwner},
+					"depends_on": schema.ListAttribute{Optional: true, Description: descriptionResourceSpecDependsOn, ElementType: types.StringType},
+					"system":     schema.StringAttribute{Optional: true, Description: descriptionResourceSpecSystem},
+				}},
+			}},
 		},
 	}
 }
@@ -149,76 +218,101 @@ func (d *resourceDataSource) Read(ctx context.Context, req datasource.ReadReques
 	tflog.Debug(ctx, fmt.Sprintf("Getting Resource kind %s/%s from Backstage API", state.Name.ValueString(), state.Namespace.ValueString()))
 	resource, response, err := d.client.Catalog.Resources.Get(ctx, state.Name.ValueString(), state.Namespace.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading Backstage Resource kind",
-			fmt.Sprintf("Could not read Backstage Resource kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error()),
-		)
-		return
+		const shortErr = "Error reading Backstage Resource kind"
+		longErr := fmt.Sprintf("Could not read Backstage Resource kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error())
+		if state.Fallback == nil {
+			resp.Diagnostics.AddError(shortErr, longErr)
+			return
+		}
+		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 
 	if response.StatusCode != http.StatusOK {
-		resp.Diagnostics.AddError(
-			"Error reading Backstage Resource kind",
-			fmt.Sprintf("Could not read Backstage Resource kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status),
-		)
-		return
+		const shortErr = "Error reading Backstage Resource kind"
+		longErr := fmt.Sprintf("Could not read Backstage Resource kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status)
+		if state.Fallback == nil {
+			resp.Diagnostics.AddError(shortErr, longErr)
+			return
+		}
+		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 
-	state.ID = types.StringValue(resource.Metadata.UID)
-	state.ApiVersion = types.StringValue(resource.ApiVersion)
-	state.Kind = types.StringValue(resource.Kind)
-
-	for _, i := range resource.Relations {
-		state.Relations = append(state.Relations, entityRelationModel{
-			Type:      types.StringValue(i.Type),
-			TargetRef: types.StringValue(i.TargetRef),
-			Target: &entityRelationTargetModel{
-				Kind:      types.StringValue(i.Target.Kind),
-				Name:      types.StringValue(i.Target.Name),
-				Namespace: types.StringValue(i.Target.Namespace)},
-		})
+	if (err != nil || response.StatusCode != http.StatusOK) && state.Fallback != nil {
+		if state.Fallback.ID.IsNull() {
+			state.Fallback.ID = types.StringValue("123456789")
+		}
+		if state.Fallback.ApiVersion.IsNull() {
+			state.Fallback.ApiVersion = types.StringValue("backstage.io/v1alpha1")
+		}
+		if state.Fallback.Kind.IsNull() {
+			state.Fallback.Kind = types.StringValue(backstage.KindResource)
+		}
+		state.ID = state.Fallback.ID
+		state.Name = state.Fallback.Name
+		state.Namespace = state.Fallback.Namespace
+		state.ApiVersion = state.Fallback.ApiVersion
+		state.Kind = state.Fallback.Kind
+		state.Metadata = state.Fallback.Metadata
+		state.Relations = state.Fallback.Relations
+		state.Spec = state.Fallback.Spec
 	}
+	if err == nil && response.StatusCode == http.StatusOK {
+		state.ID = types.StringValue(resource.Metadata.UID)
+		state.ApiVersion = types.StringValue(resource.ApiVersion)
+		state.Kind = types.StringValue(resource.Kind)
 
-	state.Spec = &resourceSpecModel{
-		Type:   types.StringValue(resource.Spec.Type),
-		Owner:  types.StringValue(resource.Spec.Owner),
-		System: types.StringValue(resource.Spec.System),
-	}
+		for _, i := range resource.Relations {
+			state.Relations = append(state.Relations, entityRelationModel{
+				Type:      types.StringValue(i.Type),
+				TargetRef: types.StringValue(i.TargetRef),
+				Target: &entityRelationTargetModel{
+					Kind:      types.StringValue(i.Target.Kind),
+					Name:      types.StringValue(i.Target.Name),
+					Namespace: types.StringValue(i.Target.Namespace)},
+			})
+		}
 
-	for _, i := range resource.Spec.DependsOn {
-		state.Spec.DependsOn = append(state.Spec.DependsOn, types.StringValue(i))
-	}
+		state.Spec = &resourceSpecModel{
+			Type:   types.StringValue(resource.Spec.Type),
+			Owner:  types.StringValue(resource.Spec.Owner),
+			System: types.StringValue(resource.Spec.System),
+		}
 
-	state.Metadata = &entityMetadataModel{
-		UID:         types.StringValue(resource.Metadata.UID),
-		Etag:        types.StringValue(resource.Metadata.Etag),
-		Name:        types.StringValue(resource.Metadata.Name),
-		Namespace:   types.StringValue(resource.Metadata.Namespace),
-		Title:       types.StringValue(resource.Metadata.Title),
-		Description: types.StringValue(resource.Metadata.Description),
-		Annotations: map[string]string{},
-		Labels:      map[string]string{},
-	}
+		for _, i := range resource.Spec.DependsOn {
+			state.Spec.DependsOn = append(state.Spec.DependsOn, types.StringValue(i))
+		}
 
-	for k, v := range resource.Metadata.Labels {
-		state.Metadata.Labels[k] = v
-	}
+		state.Metadata = &entityMetadataModel{
+			UID:         types.StringValue(resource.Metadata.UID),
+			Etag:        types.StringValue(resource.Metadata.Etag),
+			Name:        types.StringValue(resource.Metadata.Name),
+			Namespace:   types.StringValue(resource.Metadata.Namespace),
+			Title:       types.StringValue(resource.Metadata.Title),
+			Description: types.StringValue(resource.Metadata.Description),
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		}
 
-	for k, v := range resource.Metadata.Annotations {
-		state.Metadata.Annotations[k] = v
-	}
+		for k, v := range resource.Metadata.Labels {
+			state.Metadata.Labels[k] = v
+		}
 
-	for _, v := range resource.Metadata.Tags {
-		state.Metadata.Tags = append(state.Metadata.Tags, types.StringValue(v))
-	}
+		for k, v := range resource.Metadata.Annotations {
+			state.Metadata.Annotations[k] = v
+		}
 
-	for _, v := range resource.Metadata.Links {
-		state.Metadata.Links = append(state.Metadata.Links, entityLinkModel{
-			URL:   types.StringValue(v.URL),
-			Title: types.StringValue(v.Title),
-			Icon:  types.StringValue(v.Icon),
-			Type:  types.StringValue(v.Type),
-		})
+		for _, v := range resource.Metadata.Tags {
+			state.Metadata.Tags = append(state.Metadata.Tags, types.StringValue(v))
+		}
+
+		for _, v := range resource.Metadata.Links {
+			state.Metadata.Links = append(state.Metadata.Links, entityLinkModel{
+				URL:   types.StringValue(v.URL),
+				Title: types.StringValue(v.Title),
+				Icon:  types.StringValue(v.Icon),
+				Type:  types.StringValue(v.Type),
+			})
+		}
 	}
 
 	diags := resp.State.Set(ctx, state)

--- a/backstage/data_source_system_test.go
+++ b/backstage/data_source_system_test.go
@@ -1,6 +1,7 @@
 package backstage
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -31,3 +32,42 @@ data "backstage_system" "test" {
   name = "artist-engagement-portal"
 }
 `
+
+func TestAccDataSourceSystem_WithFallback(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "backstage_system" "test" {
+						name = "system_not_found_humungous_a9ab8"
+						fallback = {
+							name = "fallback_system"
+						}
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.backstage_system.test", "api_version", "backstage.io/v1alpha1"),
+					resource.TestCheckResourceAttr("data.backstage_system.test", "kind", "System"),
+					resource.TestCheckResourceAttr("data.backstage_system.test", "name", "fallback_system"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceSystem_WithoutFallback_Error(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "backstage_system" "test" {
+						name = "system_not_found_huppla_a9ab8"
+					}
+				`,
+				ExpectError: regexp.MustCompile(`404 Not Found`),
+			},
+		},
+	})
+}

--- a/backstage/data_source_user.go
+++ b/backstage/data_source_user.go
@@ -39,6 +39,7 @@ type userDataSourceModel struct {
 	Metadata   *entityMetadataModel  `tfsdk:"metadata"`
 	Relations  []entityRelationModel `tfsdk:"relations"`
 	Spec       *userSpecModel        `tfsdk:"spec"`
+	Fallback   *userFallbackModel    `tfsdk:"fallback"`
 }
 
 type userSpecModel struct {
@@ -52,12 +53,24 @@ type userSpecProfileModel struct {
 	Picture     types.String `tfsdk:"picture"`
 }
 
+type userFallbackModel struct {
+	ID         types.String          `tfsdk:"id"`
+	Name       types.String          `tfsdk:"name"`
+	Namespace  types.String          `tfsdk:"namespace"`
+	ApiVersion types.String          `tfsdk:"api_version"`
+	Kind       types.String          `tfsdk:"kind"`
+	Metadata   *entityMetadataModel  `tfsdk:"metadata"`
+	Relations  []entityRelationModel `tfsdk:"relations"`
+	Spec       *userSpecModel        `tfsdk:"spec"`
+}
+
 const (
 	descriptionUserSpecProfile            = "Profile information about the user, mainly for display purposes."
 	descriptionUserSpecProfileDisplayName = "A simple display name to present to users."
 	descriptionUserSpecProfileEmail       = "Email where this user can be reached."
 	descriptionUserSpecProfilePicture     = "A URL of an image that represents this user."
 	descriptionUserSpecMemberOf           = "The list of groups that the user is a direct member of (i.e., no transitive memberships are listed here)."
+	descriptionUserFallback               = "A complete replica of the `User` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable."
 )
 
 // Metadata returns the data source type name.
@@ -127,6 +140,64 @@ func (d *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 					"picture":      schema.StringAttribute{Computed: true, Description: descriptionUserSpecProfilePicture},
 				}},
 			}},
+			"fallback": schema.SingleNestedAttribute{Optional: true, Description: descriptionUserFallback, Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+				"name": schema.StringAttribute{Required: true, Description: descriptionEntityMetadataName, Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 63),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(patternEntityName),
+						"must follow Backstage format restrictions",
+					),
+				}},
+				"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace, Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 63),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(patternEntityName),
+						"must follow Backstage format restrictions",
+					),
+				}},
+				"api_version": schema.StringAttribute{Optional: true, Description: descriptionEntityApiVersion},
+				"kind":        schema.StringAttribute{Optional: true, Description: descriptionEntityKind},
+				"metadata": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityMetadata, Attributes: map[string]schema.Attribute{
+					"uid":         schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataUID},
+					"etag":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataEtag},
+					"name":        schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataName},
+					"namespace":   schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataNamespace},
+					"title":       schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataTitle},
+					"description": schema.StringAttribute{Optional: true, Description: descriptionEntityMetadataDescription},
+					"labels":      schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataLabels, ElementType: types.StringType},
+					"annotations": schema.MapAttribute{Optional: true, Description: descriptionEntityMetadataAnnotations, ElementType: types.StringType},
+					"tags":        schema.ListAttribute{Optional: true, Description: descriptionEntityMetadataTags, ElementType: types.StringType},
+					"links": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityMetadataLinks, NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"url":   schema.StringAttribute{Optional: true, Description: descriptionEntityLinkURL},
+							"title": schema.StringAttribute{Optional: true, Description: descriptionEntityLinkTitle},
+							"icon":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkIco},
+							"type":  schema.StringAttribute{Optional: true, Description: descriptionEntityLinkType},
+						},
+					}},
+				}},
+				"relations": schema.ListNestedAttribute{Optional: true, Description: descriptionEntityRelations, NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type":       schema.StringAttribute{Optional: true, Description: descriptionEntityRelationType},
+						"target_ref": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetRef},
+						"target": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntityRelationTarget,
+							Attributes: map[string]schema.Attribute{
+								"name":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetName},
+								"kind":      schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetKind},
+								"namespace": schema.StringAttribute{Optional: true, Description: descriptionEntityRelationTargetNamespace},
+							}},
+					},
+				}},
+				"spec": schema.SingleNestedAttribute{Optional: true, Description: descriptionEntitySpec, Attributes: map[string]schema.Attribute{
+					"member_of": schema.ListAttribute{Optional: true, Description: descriptionUserSpecMemberOf, ElementType: types.StringType},
+					"profile": schema.SingleNestedAttribute{Optional: true, Description: descriptionUserSpecProfile, Attributes: map[string]schema.Attribute{
+						"display_name": schema.StringAttribute{Optional: true, Description: descriptionUserSpecProfileDisplayName},
+						"email":        schema.StringAttribute{Optional: true, Description: descriptionUserSpecProfileEmail},
+						"picture":      schema.StringAttribute{Optional: true, Description: descriptionUserSpecProfilePicture},
+					}},
+				}},
+			}},
 		},
 	}
 }
@@ -156,78 +227,104 @@ func (d *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	tflog.Debug(ctx, fmt.Sprintf("Getting User kind %s/%s from Backstage API", state.Name.ValueString(), state.Namespace.ValueString()))
 	user, response, err := d.client.Catalog.Users.Get(ctx, state.Name.ValueString(), state.Namespace.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading Backstage User kind",
-			fmt.Sprintf("Could not read Backstage User kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error()),
-		)
-		return
+		const shortErr = "Error reading Backstage User kind"
+		longErr := fmt.Sprintf("Could not read Backstage User kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), err.Error())
+		if state.Fallback == nil {
+			resp.Diagnostics.AddError(shortErr, longErr)
+			return
+		}
+		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 
 	if response.StatusCode != http.StatusOK {
-		resp.Diagnostics.AddError(
-			"Error reading Backstage User kind",
-			fmt.Sprintf("Could not read Backstage User kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status),
-		)
-		return
+		const shortErr = "Error reading Backstage User kind"
+		longErr := fmt.Sprintf("Could not read Backstage User kind %s/%s: %s", state.Namespace.ValueString(), state.Name.ValueString(), response.Status)
+		if state.Fallback == nil {
+			resp.Diagnostics.AddError(shortErr, longErr)
+			return
+		}
+		resp.Diagnostics.AddWarning(shortErr, longErr)
 	}
 
-	state.ID = types.StringValue(user.Metadata.UID)
-	state.ApiVersion = types.StringValue(user.ApiVersion)
-	state.Kind = types.StringValue(user.Kind)
-
-	for _, i := range user.Relations {
-		state.Relations = append(state.Relations, entityRelationModel{
-			Type:      types.StringValue(i.Type),
-			TargetRef: types.StringValue(i.TargetRef),
-			Target: &entityRelationTargetModel{
-				Kind:      types.StringValue(i.Target.Kind),
-				Name:      types.StringValue(i.Target.Name),
-				Namespace: types.StringValue(i.Target.Namespace)},
-		})
+	if (err != nil || response.StatusCode != http.StatusOK) && state.Fallback != nil {
+		if state.Fallback.ID.IsNull() {
+			state.Fallback.ID = types.StringValue("123456789")
+		}
+		if state.Fallback.ApiVersion.IsNull() {
+			state.Fallback.ApiVersion = types.StringValue("backstage.io/v1alpha1")
+		}
+		if state.Fallback.Kind.IsNull() {
+			state.Fallback.Kind = types.StringValue(backstage.KindSystem)
+		}
+		state.ID = state.Fallback.ID
+		state.Name = state.Fallback.Name
+		state.Namespace = state.Fallback.Namespace
+		state.ApiVersion = state.Fallback.ApiVersion
+		state.Kind = state.Fallback.Kind
+		state.Metadata = state.Fallback.Metadata
+		state.Relations = state.Fallback.Relations
+		state.Spec = state.Fallback.Spec
 	}
 
-	state.Spec = &userSpecModel{
-		Profile: &userSpecProfileModel{
-			DisplayName: types.StringValue(user.Spec.Profile.DisplayName),
-			Email:       types.StringValue(user.Spec.Profile.Email),
-			Picture:     types.StringValue(user.Spec.Profile.Picture),
-		},
-	}
+	if err == nil && response.StatusCode == http.StatusOK {
+		state.ID = types.StringValue(user.Metadata.UID)
+		state.ApiVersion = types.StringValue(user.ApiVersion)
+		state.Kind = types.StringValue(user.Kind)
 
-	for _, i := range user.Spec.MemberOf {
-		state.Spec.MemberOf = append(state.Spec.MemberOf, types.StringValue(i))
-	}
+		for _, i := range user.Relations {
+			state.Relations = append(state.Relations, entityRelationModel{
+				Type:      types.StringValue(i.Type),
+				TargetRef: types.StringValue(i.TargetRef),
+				Target: &entityRelationTargetModel{
+					Kind:      types.StringValue(i.Target.Kind),
+					Name:      types.StringValue(i.Target.Name),
+					Namespace: types.StringValue(i.Target.Namespace)},
+			})
+		}
 
-	state.Metadata = &entityMetadataModel{
-		UID:         types.StringValue(user.Metadata.UID),
-		Etag:        types.StringValue(user.Metadata.Etag),
-		Name:        types.StringValue(user.Metadata.Name),
-		Namespace:   types.StringValue(user.Metadata.Namespace),
-		Title:       types.StringValue(user.Metadata.Title),
-		Description: types.StringValue(user.Metadata.Description),
-		Annotations: map[string]string{},
-		Labels:      map[string]string{},
-	}
+		state.Spec = &userSpecModel{
+			Profile: &userSpecProfileModel{
+				DisplayName: types.StringValue(user.Spec.Profile.DisplayName),
+				Email:       types.StringValue(user.Spec.Profile.Email),
+				Picture:     types.StringValue(user.Spec.Profile.Picture),
+			},
+		}
 
-	for k, v := range user.Metadata.Labels {
-		state.Metadata.Labels[k] = v
-	}
+		for _, i := range user.Spec.MemberOf {
+			state.Spec.MemberOf = append(state.Spec.MemberOf, types.StringValue(i))
+		}
 
-	for k, v := range user.Metadata.Annotations {
-		state.Metadata.Annotations[k] = v
-	}
+		state.Metadata = &entityMetadataModel{
+			UID:         types.StringValue(user.Metadata.UID),
+			Etag:        types.StringValue(user.Metadata.Etag),
+			Name:        types.StringValue(user.Metadata.Name),
+			Namespace:   types.StringValue(user.Metadata.Namespace),
+			Title:       types.StringValue(user.Metadata.Title),
+			Description: types.StringValue(user.Metadata.Description),
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		}
 
-	for _, v := range user.Metadata.Tags {
-		state.Metadata.Tags = append(state.Metadata.Tags, types.StringValue(v))
-	}
+		for k, v := range user.Metadata.Labels {
+			state.Metadata.Labels[k] = v
+		}
 
-	for _, v := range user.Metadata.Links {
-		state.Metadata.Links = append(state.Metadata.Links, entityLinkModel{
-			URL:   types.StringValue(v.URL),
-			Title: types.StringValue(v.Title),
-			Icon:  types.StringValue(v.Icon),
-			Type:  types.StringValue(v.Type),
-		})
+		for k, v := range user.Metadata.Annotations {
+			state.Metadata.Annotations[k] = v
+		}
+
+		for _, v := range user.Metadata.Tags {
+			state.Metadata.Tags = append(state.Metadata.Tags, types.StringValue(v))
+		}
+
+		for _, v := range user.Metadata.Links {
+			state.Metadata.Links = append(state.Metadata.Links, entityLinkModel{
+				URL:   types.StringValue(v.URL),
+				Title: types.StringValue(v.Title),
+				Icon:  types.StringValue(v.Icon),
+				Type:  types.StringValue(v.Type),
+			})
+		}
 	}
 
 	diags := resp.State.Set(ctx, state)

--- a/backstage/data_source_user_test.go
+++ b/backstage/data_source_user_test.go
@@ -1,6 +1,7 @@
 package backstage
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -32,3 +33,42 @@ data "backstage_user" "test" {
   name = "janelle.dawe"
 }
 `
+
+func TestAccDataSourceUser_WithFallback(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "backstage_user" "test" {
+						name = "user_not_found_blasted_a9ab8"
+						fallback = {
+							name = "fallback_user"
+						}
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.backstage_user.test", "api_version", "backstage.io/v1alpha1"),
+					resource.TestCheckResourceAttr("data.backstage_user.test", "kind", "System"),
+					resource.TestCheckResourceAttr("data.backstage_user.test", "name", "fallback_user"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceUser_WithoutFallback_Error(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "backstage_user" "test" {
+						name = "user_not_found_emoji_a9ab8"
+					}
+				`,
+				ExpectError: regexp.MustCompile(`default/user_not_found_emoji_a9ab8`),
+			},
+		},
+	})
+}

--- a/docs/data-sources/api.md
+++ b/docs/data-sources/api.md
@@ -31,6 +31,7 @@ data "backstage_api" "example" {
 
 ### Optional
 
+- `fallback` (Attributes) A complete replica of the `API` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable. (see [below for nested schema](#nestedatt--fallback))
 - `namespace` (String) Namespace that the entity belongs to.
 
 ### Read-Only
@@ -41,6 +42,81 @@ data "backstage_api" "example" {
 - `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--metadata))
 - `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--relations))
 - `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--spec))
+
+<a id="nestedatt--fallback"></a>
+### Nested Schema for `fallback`
+
+Optional:
+
+- `api_version` (String) Version of specification format for this particular entity that this is written against.
+- `id` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+- `kind` (String) The high level entity type being described.
+- `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--fallback--metadata))
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the entity belongs to.
+- `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--fallback--relations))
+- `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--fallback--spec))
+
+<a id="nestedatt--fallback--metadata"></a>
+### Nested Schema for `fallback.metadata`
+
+Optional:
+
+- `annotations` (Map of String) Key/Value pairs of non-identifying auxiliary information attached to entity.
+- `description` (String) A short (typically relatively few words) description of the entity.
+- `etag` (String) An opaque string that changes for each update operation to any part of the entity, including metadata. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.The field can (optionally) be specified when performing update or delete operations, and the server will then reject the operation if it does not match the current stored value.
+- `labels` (Map of String) Key/Value pairs of identifying information attached to the entity.
+- `links` (Attributes List) A list of external hyperlinks related to the entity. Links can provide additional contextual information that may be located outside of Backstage itself. For example, an admin dashboard or external CMS page. (see [below for nested schema](#nestedatt--fallback--metadata--links))
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the entity belongs to.
+- `tags` (List of String) A list of single-valued strings, to for example classify catalog entities in various ways.
+- `title` (String) A display name of the entity, to be presented in user interfaces instead of the name property, when available.
+- `uid` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+
+<a id="nestedatt--fallback--metadata--links"></a>
+### Nested Schema for `fallback.metadata.links`
+
+Optional:
+
+- `icon` (String) A key representing a visual icon to be displayed in the UI.
+- `title` (String) A user-friendly display name for the link.
+- `type` (String) An optional value to categorize links into specific groups.
+- `url` (String) URL in a standard uri format.
+
+
+
+<a id="nestedatt--fallback--relations"></a>
+### Nested Schema for `fallback.relations`
+
+Optional:
+
+- `target` (Attributes) The entity of the target of this relation. (see [below for nested schema](#nestedatt--fallback--relations--target))
+- `target_ref` (String) The entity ref of the target of this relation.
+- `type` (String) Type of the relation.
+
+<a id="nestedatt--fallback--relations--target"></a>
+### Nested Schema for `fallback.relations.target`
+
+Optional:
+
+- `kind` (String) The high level entity type being described.
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the target entity belongs to.
+
+
+
+<a id="nestedatt--fallback--spec"></a>
+### Nested Schema for `fallback.spec`
+
+Optional:
+
+- `definition` (String) Definition of the API, based on the format defined by the type.
+- `lifecycle` (String) Lifecycle state of the API.
+- `owner` (String) An entity reference to the owner of the API
+- `system` (String) An entity reference to the system that the API belongs to.
+- `type` (String) Type of the API definition.
+
+
 
 <a id="nestedatt--metadata"></a>
 ### Nested Schema for `metadata`

--- a/docs/data-sources/component.md
+++ b/docs/data-sources/component.md
@@ -31,6 +31,7 @@ data "backstage_component" "example" {
 
 ### Optional
 
+- `fallback` (Attributes) A complete replica of the `Component` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable. (see [below for nested schema](#nestedatt--fallback))
 - `namespace` (String) Namespace that the entity belongs to.
 
 ### Read-Only
@@ -41,6 +42,84 @@ data "backstage_component" "example" {
 - `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--metadata))
 - `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--relations))
 - `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--spec))
+
+<a id="nestedatt--fallback"></a>
+### Nested Schema for `fallback`
+
+Optional:
+
+- `api_version` (String) Version of specification format for this particular entity that this is written against.
+- `id` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+- `kind` (String) The high level entity type being described.
+- `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--fallback--metadata))
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the entity belongs to.
+- `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--fallback--relations))
+- `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--fallback--spec))
+
+<a id="nestedatt--fallback--metadata"></a>
+### Nested Schema for `fallback.metadata`
+
+Optional:
+
+- `annotations` (Map of String) Key/Value pairs of non-identifying auxiliary information attached to entity.
+- `description` (String) A short (typically relatively few words) description of the entity.
+- `etag` (String) An opaque string that changes for each update operation to any part of the entity, including metadata. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.The field can (optionally) be specified when performing update or delete operations, and the server will then reject the operation if it does not match the current stored value.
+- `labels` (Map of String) Key/Value pairs of identifying information attached to the entity.
+- `links` (Attributes List) A list of external hyperlinks related to the entity. Links can provide additional contextual information that may be located outside of Backstage itself. For example, an admin dashboard or external CMS page. (see [below for nested schema](#nestedatt--fallback--metadata--links))
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the entity belongs to.
+- `tags` (List of String) A list of single-valued strings, to for example classify catalog entities in various ways.
+- `title` (String) A display name of the entity, to be presented in user interfaces instead of the name property, when available.
+- `uid` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+
+<a id="nestedatt--fallback--metadata--links"></a>
+### Nested Schema for `fallback.metadata.links`
+
+Optional:
+
+- `icon` (String) A key representing a visual icon to be displayed in the UI.
+- `title` (String) A user-friendly display name for the link.
+- `type` (String) An optional value to categorize links into specific groups.
+- `url` (String) URL in a standard uri format.
+
+
+
+<a id="nestedatt--fallback--relations"></a>
+### Nested Schema for `fallback.relations`
+
+Optional:
+
+- `target` (Attributes) The entity of the target of this relation. (see [below for nested schema](#nestedatt--fallback--relations--target))
+- `target_ref` (String) The entity ref of the target of this relation.
+- `type` (String) Type of the relation.
+
+<a id="nestedatt--fallback--relations--target"></a>
+### Nested Schema for `fallback.relations.target`
+
+Optional:
+
+- `kind` (String) The high level entity type being described.
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the target entity belongs to.
+
+
+
+<a id="nestedatt--fallback--spec"></a>
+### Nested Schema for `fallback.spec`
+
+Optional:
+
+- `consumes_apis` (List of String) An array of entity references to the APIs that are consumed by the component.
+- `depends_on` (List of String) An array of entity references to the components and resources that the component depends on.
+- `lifecycle` (String) Lifecycle state of the component.
+- `owner` (String) An entity reference to the owner of the component
+- `provides_apis` (List of String) An array of entity references to the APIs that are provided by the component.
+- `subcomponent_of` (String) An entity reference to another component of which the component is a part.
+- `system` (String) An entity reference to the system that the component belongs to.
+- `type` (String) Type of the component definition.
+
+
 
 <a id="nestedatt--metadata"></a>
 ### Nested Schema for `metadata`

--- a/docs/data-sources/domain.md
+++ b/docs/data-sources/domain.md
@@ -31,6 +31,7 @@ data "backstage_domain" "example" {
 
 ### Optional
 
+- `fallback` (Attributes) A complete replica of the `Domain` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable. (see [below for nested schema](#nestedatt--fallback))
 - `namespace` (String) Namespace that the entity belongs to.
 
 ### Read-Only
@@ -41,6 +42,80 @@ data "backstage_domain" "example" {
 - `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--metadata))
 - `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--relations))
 - `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--spec))
+
+<a id="nestedatt--fallback"></a>
+### Nested Schema for `fallback`
+
+Required:
+
+- `name` (String) Name of the entity.
+
+Optional:
+
+- `api_version` (String) Version of specification format for this particular entity that this is written against.
+- `id` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+- `kind` (String) The high level entity type being described.
+- `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--fallback--metadata))
+- `namespace` (String) Namespace that the entity belongs to.
+- `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--fallback--relations))
+- `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--fallback--spec))
+
+<a id="nestedatt--fallback--metadata"></a>
+### Nested Schema for `fallback.metadata`
+
+Optional:
+
+- `annotations` (Map of String) Key/Value pairs of non-identifying auxiliary information attached to entity.
+- `description` (String) A short (typically relatively few words) description of the entity.
+- `etag` (String) An opaque string that changes for each update operation to any part of the entity, including metadata. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.The field can (optionally) be specified when performing update or delete operations, and the server will then reject the operation if it does not match the current stored value.
+- `labels` (Map of String) Key/Value pairs of identifying information attached to the entity.
+- `links` (Attributes List) A list of external hyperlinks related to the entity. Links can provide additional contextual information that may be located outside of Backstage itself. For example, an admin dashboard or external CMS page. (see [below for nested schema](#nestedatt--fallback--metadata--links))
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the entity belongs to.
+- `tags` (List of String) A list of single-valued strings, to for example classify catalog entities in various ways.
+- `title` (String) A display name of the entity, to be presented in user interfaces instead of the name property, when available.
+- `uid` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+
+<a id="nestedatt--fallback--metadata--links"></a>
+### Nested Schema for `fallback.metadata.links`
+
+Optional:
+
+- `icon` (String) A key representing a visual icon to be displayed in the UI.
+- `title` (String) A user-friendly display name for the link.
+- `type` (String) An optional value to categorize links into specific groups.
+- `url` (String) URL in a standard uri format.
+
+
+
+<a id="nestedatt--fallback--relations"></a>
+### Nested Schema for `fallback.relations`
+
+Optional:
+
+- `target` (Attributes) The entity of the target of this relation. (see [below for nested schema](#nestedatt--fallback--relations--target))
+- `target_ref` (String) The entity ref of the target of this relation.
+- `type` (String) Type of the relation.
+
+<a id="nestedatt--fallback--relations--target"></a>
+### Nested Schema for `fallback.relations.target`
+
+Optional:
+
+- `kind` (String) The high level entity type being described.
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the target entity belongs to.
+
+
+
+<a id="nestedatt--fallback--spec"></a>
+### Nested Schema for `fallback.spec`
+
+Optional:
+
+- `owner` (String) An entity reference to the owner of the domain.
+
+
 
 <a id="nestedatt--metadata"></a>
 ### Nested Schema for `metadata`

--- a/docs/data-sources/entities.md
+++ b/docs/data-sources/entities.md
@@ -35,10 +35,87 @@ output "example" {
 
 - `filters` (List of String) A set of conditions that can be used to filter entities.
 
+### Optional
+
+- `fallback` (Attributes) A complete replica of the `Entity` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable. (see [below for nested schema](#nestedatt--fallback))
+
 ### Read-Only
 
 - `entities` (Attributes List) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--entities))
 - `id` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+
+<a id="nestedatt--fallback"></a>
+### Nested Schema for `fallback`
+
+Required:
+
+- `filters` (List of String) A set of conditions that can be used to filter entities.
+
+Optional:
+
+- `entities` (Attributes List) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--fallback--entities))
+- `id` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+
+<a id="nestedatt--fallback--entities"></a>
+### Nested Schema for `fallback.entities`
+
+Optional:
+
+- `api_version` (String) Version of specification format for this particular entity that this is written against.
+- `kind` (String) The high level entity type being described.
+- `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--fallback--entities--metadata))
+- `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--fallback--entities--relations))
+- `spec` (String) The specification data describing the entity itself (as JSON).
+
+<a id="nestedatt--fallback--entities--metadata"></a>
+### Nested Schema for `fallback.entities.metadata`
+
+Optional:
+
+- `annotations` (Map of String) Key/Value pairs of non-identifying auxiliary information attached to entity.
+- `description` (String) A short (typically relatively few words) description of the entity.
+- `etag` (String) An opaque string that changes for each update operation to any part of the entity, including metadata. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.The field can (optionally) be specified when performing update or delete operations, and the server will then reject the operation if it does not match the current stored value.
+- `labels` (Map of String) Key/Value pairs of identifying information attached to the entity.
+- `links` (Attributes List) A list of external hyperlinks related to the entity. Links can provide additional contextual information that may be located outside of Backstage itself. For example, an admin dashboard or external CMS page. (see [below for nested schema](#nestedatt--fallback--entities--metadata--links))
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the entity belongs to.
+- `tags` (List of String) A list of single-valued strings, to for example classify catalog entities in various ways.
+- `title` (String) A display name of the entity, to be presented in user interfaces instead of the name property, when available.
+- `uid` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+
+<a id="nestedatt--fallback--entities--metadata--links"></a>
+### Nested Schema for `fallback.entities.metadata.links`
+
+Optional:
+
+- `icon` (String) A key representing a visual icon to be displayed in the UI.
+- `title` (String) A user-friendly display name for the link.
+- `type` (String) An optional value to categorize links into specific groups.
+- `url` (String) URL in a standard uri format.
+
+
+
+<a id="nestedatt--fallback--entities--relations"></a>
+### Nested Schema for `fallback.entities.relations`
+
+Optional:
+
+- `target` (Attributes) The entity of the target of this relation. (see [below for nested schema](#nestedatt--fallback--entities--relations--target))
+- `target_ref` (String) The entity ref of the target of this relation.
+- `type` (String) Type of the relation.
+
+<a id="nestedatt--fallback--entities--relations--target"></a>
+### Nested Schema for `fallback.entities.relations.target`
+
+Optional:
+
+- `kind` (String) The high level entity type being described.
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the target entity belongs to.
+
+
+
+
 
 <a id="nestedatt--entities"></a>
 ### Nested Schema for `entities`

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -31,6 +31,7 @@ data "backstage_group" "example" {
 
 ### Optional
 
+- `fallback` (Attributes) A complete replica of the `Group` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable. (see [below for nested schema](#nestedatt--fallback))
 - `namespace` (String) Namespace that the entity belongs to.
 
 ### Read-Only
@@ -41,6 +42,94 @@ data "backstage_group" "example" {
 - `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--metadata))
 - `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--relations))
 - `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--spec))
+
+<a id="nestedatt--fallback"></a>
+### Nested Schema for `fallback`
+
+Required:
+
+- `name` (String) Name of the entity.
+
+Optional:
+
+- `api_version` (String) Version of specification format for this particular entity that this is written against.
+- `id` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+- `kind` (String) The high level entity type being described.
+- `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--fallback--metadata))
+- `namespace` (String) Namespace that the entity belongs to.
+- `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--fallback--relations))
+- `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--fallback--spec))
+
+<a id="nestedatt--fallback--metadata"></a>
+### Nested Schema for `fallback.metadata`
+
+Optional:
+
+- `annotations` (Map of String) Key/Value pairs of non-identifying auxiliary information attached to entity.
+- `description` (String) A short (typically relatively few words) description of the entity.
+- `etag` (String) An opaque string that changes for each update operation to any part of the entity, including metadata. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.The field can (optionally) be specified when performing update or delete operations, and the server will then reject the operation if it does not match the current stored value.
+- `labels` (Map of String) Key/Value pairs of identifying information attached to the entity.
+- `links` (Attributes List) A list of external hyperlinks related to the entity. Links can provide additional contextual information that may be located outside of Backstage itself. For example, an admin dashboard or external CMS page. (see [below for nested schema](#nestedatt--fallback--metadata--links))
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the entity belongs to.
+- `tags` (List of String) A list of single-valued strings, to for example classify catalog entities in various ways.
+- `title` (String) A display name of the entity, to be presented in user interfaces instead of the name property, when available.
+- `uid` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+
+<a id="nestedatt--fallback--metadata--links"></a>
+### Nested Schema for `fallback.metadata.links`
+
+Optional:
+
+- `icon` (String) A key representing a visual icon to be displayed in the UI.
+- `title` (String) A user-friendly display name for the link.
+- `type` (String) An optional value to categorize links into specific groups.
+- `url` (String) URL in a standard uri format.
+
+
+
+<a id="nestedatt--fallback--relations"></a>
+### Nested Schema for `fallback.relations`
+
+Optional:
+
+- `target` (Attributes) The entity of the target of this relation. (see [below for nested schema](#nestedatt--fallback--relations--target))
+- `target_ref` (String) The entity ref of the target of this relation.
+- `type` (String) Type of the relation.
+
+<a id="nestedatt--fallback--relations--target"></a>
+### Nested Schema for `fallback.relations.target`
+
+Optional:
+
+- `kind` (String) The high level entity type being described.
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the target entity belongs to.
+
+
+
+<a id="nestedatt--fallback--spec"></a>
+### Nested Schema for `fallback.spec`
+
+Optional:
+
+- `children` (List of String) Children contains immediate child groups of this group in the hierarchy (whose parent field points to this group).
+- `members` (List of String) Members contains the users that are members of this group.
+- `parent` (String) Parent is the immediate parent group in the hierarchy, if any.
+- `profile` (Attributes) Profile information about the group, mainly for display purposes. (see [below for nested schema](#nestedatt--fallback--spec--profile))
+- `type` (String) The type of group.
+
+<a id="nestedatt--fallback--spec--profile"></a>
+### Nested Schema for `fallback.spec.profile`
+
+Optional:
+
+- `display_name` (String) A simple display name to present to users.
+- `email` (String) Email where this entity can be reached.
+- `picture` (String) A URL of an image that represents this entity.
+
+
+
 
 <a id="nestedatt--metadata"></a>
 ### Nested Schema for `metadata`

--- a/docs/data-sources/location.md
+++ b/docs/data-sources/location.md
@@ -31,6 +31,7 @@ data "backstage_location" "example" {
 
 ### Optional
 
+- `fallback` (Attributes) A complete replica of the `Location` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable. (see [below for nested schema](#nestedatt--fallback))
 - `namespace` (String) Namespace that the entity belongs to.
 
 ### Read-Only
@@ -41,6 +42,83 @@ data "backstage_location" "example" {
 - `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--metadata))
 - `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--relations))
 - `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--spec))
+
+<a id="nestedatt--fallback"></a>
+### Nested Schema for `fallback`
+
+Required:
+
+- `name` (String) Name of the entity.
+
+Optional:
+
+- `api_version` (String) Version of specification format for this particular entity that this is written against.
+- `id` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+- `kind` (String) The high level entity type being described.
+- `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--fallback--metadata))
+- `namespace` (String) Namespace that the entity belongs to.
+- `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--fallback--relations))
+- `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--fallback--spec))
+
+<a id="nestedatt--fallback--metadata"></a>
+### Nested Schema for `fallback.metadata`
+
+Optional:
+
+- `annotations` (Map of String) Key/Value pairs of non-identifying auxiliary information attached to entity.
+- `description` (String) A short (typically relatively few words) description of the entity.
+- `etag` (String) An opaque string that changes for each update operation to any part of the entity, including metadata. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.The field can (optionally) be specified when performing update or delete operations, and the server will then reject the operation if it does not match the current stored value.
+- `labels` (Map of String) Key/Value pairs of identifying information attached to the entity.
+- `links` (Attributes List) A list of external hyperlinks related to the entity. Links can provide additional contextual information that may be located outside of Backstage itself. For example, an admin dashboard or external CMS page. (see [below for nested schema](#nestedatt--fallback--metadata--links))
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the entity belongs to.
+- `tags` (List of String) A list of single-valued strings, to for example classify catalog entities in various ways.
+- `title` (String) A display name of the entity, to be presented in user interfaces instead of the name property, when available.
+- `uid` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+
+<a id="nestedatt--fallback--metadata--links"></a>
+### Nested Schema for `fallback.metadata.links`
+
+Optional:
+
+- `icon` (String) A key representing a visual icon to be displayed in the UI.
+- `title` (String) A user-friendly display name for the link.
+- `type` (String) An optional value to categorize links into specific groups.
+- `url` (String) URL in a standard uri format.
+
+
+
+<a id="nestedatt--fallback--relations"></a>
+### Nested Schema for `fallback.relations`
+
+Optional:
+
+- `target` (Attributes) The entity of the target of this relation. (see [below for nested schema](#nestedatt--fallback--relations--target))
+- `target_ref` (String) The entity ref of the target of this relation.
+- `type` (String) Type of the relation.
+
+<a id="nestedatt--fallback--relations--target"></a>
+### Nested Schema for `fallback.relations.target`
+
+Optional:
+
+- `kind` (String) The high level entity type being described.
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the target entity belongs to.
+
+
+
+<a id="nestedatt--fallback--spec"></a>
+### Nested Schema for `fallback.spec`
+
+Optional:
+
+- `presence` (String) Presence describes whether the presence of the location target is required and it should be considered an error if it can not be found.
+- `target` (String) Target as a string. Can be either an absolute path/URL (depending on the type), or a relative path such as./details/catalog-info.yaml which is resolved relative to the location of this Location entity itself.
+- `targets` (List of String) A list of targets as strings. They can all be either absolute paths/URLs (depending on the type), or relative paths such as./details/catalog-info.yaml which are resolved relative to the location of this Location entity itself.
+- `type` (String) The single location type, that's common to the targets specified in the spec. If it is left out, it is inherited from the location type that originally read the entity data.
+
+
 
 <a id="nestedatt--metadata"></a>
 ### Nested Schema for `metadata`

--- a/docs/data-sources/resource.md
+++ b/docs/data-sources/resource.md
@@ -31,6 +31,7 @@ data "backstage_resource" "example" {
 
 ### Optional
 
+- `fallback` (Attributes) A complete replica of the `Resource` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable. (see [below for nested schema](#nestedatt--fallback))
 - `namespace` (String) Namespace that the entity belongs to.
 
 ### Read-Only
@@ -41,6 +42,83 @@ data "backstage_resource" "example" {
 - `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--metadata))
 - `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--relations))
 - `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--spec))
+
+<a id="nestedatt--fallback"></a>
+### Nested Schema for `fallback`
+
+Required:
+
+- `name` (String) Name of the entity.
+
+Optional:
+
+- `api_version` (String) Version of specification format for this particular entity that this is written against.
+- `id` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+- `kind` (String) The high level entity type being described.
+- `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--fallback--metadata))
+- `namespace` (String) Namespace that the entity belongs to.
+- `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--fallback--relations))
+- `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--fallback--spec))
+
+<a id="nestedatt--fallback--metadata"></a>
+### Nested Schema for `fallback.metadata`
+
+Optional:
+
+- `annotations` (Map of String) Key/Value pairs of non-identifying auxiliary information attached to entity.
+- `description` (String) A short (typically relatively few words) description of the entity.
+- `etag` (String) An opaque string that changes for each update operation to any part of the entity, including metadata. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.The field can (optionally) be specified when performing update or delete operations, and the server will then reject the operation if it does not match the current stored value.
+- `labels` (Map of String) Key/Value pairs of identifying information attached to the entity.
+- `links` (Attributes List) A list of external hyperlinks related to the entity. Links can provide additional contextual information that may be located outside of Backstage itself. For example, an admin dashboard or external CMS page. (see [below for nested schema](#nestedatt--fallback--metadata--links))
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the entity belongs to.
+- `tags` (List of String) A list of single-valued strings, to for example classify catalog entities in various ways.
+- `title` (String) A display name of the entity, to be presented in user interfaces instead of the name property, when available.
+- `uid` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+
+<a id="nestedatt--fallback--metadata--links"></a>
+### Nested Schema for `fallback.metadata.links`
+
+Optional:
+
+- `icon` (String) A key representing a visual icon to be displayed in the UI.
+- `title` (String) A user-friendly display name for the link.
+- `type` (String) An optional value to categorize links into specific groups.
+- `url` (String) URL in a standard uri format.
+
+
+
+<a id="nestedatt--fallback--relations"></a>
+### Nested Schema for `fallback.relations`
+
+Optional:
+
+- `target` (Attributes) The entity of the target of this relation. (see [below for nested schema](#nestedatt--fallback--relations--target))
+- `target_ref` (String) The entity ref of the target of this relation.
+- `type` (String) Type of the relation.
+
+<a id="nestedatt--fallback--relations--target"></a>
+### Nested Schema for `fallback.relations.target`
+
+Optional:
+
+- `kind` (String) The high level entity type being described.
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the target entity belongs to.
+
+
+
+<a id="nestedatt--fallback--spec"></a>
+### Nested Schema for `fallback.spec`
+
+Optional:
+
+- `depends_on` (List of String) An array of references to other entities that the resource depends on to function.
+- `owner` (String) An entity reference to the owner of the resource
+- `system` (String) An entity reference to the system that the resource belongs to.
+- `type` (String) Type of the resource definition.
+
+
 
 <a id="nestedatt--metadata"></a>
 ### Nested Schema for `metadata`

--- a/docs/data-sources/system.md
+++ b/docs/data-sources/system.md
@@ -31,6 +31,7 @@ data "backstage_system" "example" {
 
 ### Optional
 
+- `fallback` (Attributes) A complete replica of the `System` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable. (see [below for nested schema](#nestedatt--fallback))
 - `namespace` (String) Namespace that the entity belongs to.
 
 ### Read-Only
@@ -41,6 +42,81 @@ data "backstage_system" "example" {
 - `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--metadata))
 - `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--relations))
 - `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--spec))
+
+<a id="nestedatt--fallback"></a>
+### Nested Schema for `fallback`
+
+Required:
+
+- `name` (String) Name of the entity.
+
+Optional:
+
+- `api_version` (String) Version of specification format for this particular entity that this is written against.
+- `id` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+- `kind` (String) The high level entity type being described.
+- `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--fallback--metadata))
+- `namespace` (String) Namespace that the entity belongs to.
+- `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--fallback--relations))
+- `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--fallback--spec))
+
+<a id="nestedatt--fallback--metadata"></a>
+### Nested Schema for `fallback.metadata`
+
+Optional:
+
+- `annotations` (Map of String) Key/Value pairs of non-identifying auxiliary information attached to entity.
+- `description` (String) A short (typically relatively few words) description of the entity.
+- `etag` (String) An opaque string that changes for each update operation to any part of the entity, including metadata. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.The field can (optionally) be specified when performing update or delete operations, and the server will then reject the operation if it does not match the current stored value.
+- `labels` (Map of String) Key/Value pairs of identifying information attached to the entity.
+- `links` (Attributes List) A list of external hyperlinks related to the entity. Links can provide additional contextual information that may be located outside of Backstage itself. For example, an admin dashboard or external CMS page. (see [below for nested schema](#nestedatt--fallback--metadata--links))
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the entity belongs to.
+- `tags` (List of String) A list of single-valued strings, to for example classify catalog entities in various ways.
+- `title` (String) A display name of the entity, to be presented in user interfaces instead of the name property, when available.
+- `uid` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+
+<a id="nestedatt--fallback--metadata--links"></a>
+### Nested Schema for `fallback.metadata.links`
+
+Optional:
+
+- `icon` (String) A key representing a visual icon to be displayed in the UI.
+- `title` (String) A user-friendly display name for the link.
+- `type` (String) An optional value to categorize links into specific groups.
+- `url` (String) URL in a standard uri format.
+
+
+
+<a id="nestedatt--fallback--relations"></a>
+### Nested Schema for `fallback.relations`
+
+Optional:
+
+- `target` (Attributes) The entity of the target of this relation. (see [below for nested schema](#nestedatt--fallback--relations--target))
+- `target_ref` (String) The entity ref of the target of this relation.
+- `type` (String) Type of the relation.
+
+<a id="nestedatt--fallback--relations--target"></a>
+### Nested Schema for `fallback.relations.target`
+
+Optional:
+
+- `kind` (String) The high level entity type being described.
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the target entity belongs to.
+
+
+
+<a id="nestedatt--fallback--spec"></a>
+### Nested Schema for `fallback.spec`
+
+Optional:
+
+- `domain` (String) An entity reference to the domain that the system belongs to.
+- `owner` (String) An entity reference to the owner of the system.
+
+
 
 <a id="nestedatt--metadata"></a>
 ### Nested Schema for `metadata`

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -31,6 +31,7 @@ data "backstage_user" "example" {
 
 ### Optional
 
+- `fallback` (Attributes) A complete replica of the `User` as it would exist in backstage. Set this to provide a fallback in case the Backstage instance is not functioning, is down, or is unrealiable. (see [below for nested schema](#nestedatt--fallback))
 - `namespace` (String) Namespace that the entity belongs to.
 
 ### Read-Only
@@ -41,6 +42,91 @@ data "backstage_user" "example" {
 - `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--metadata))
 - `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--relations))
 - `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--spec))
+
+<a id="nestedatt--fallback"></a>
+### Nested Schema for `fallback`
+
+Required:
+
+- `name` (String) Name of the entity.
+
+Optional:
+
+- `api_version` (String) Version of specification format for this particular entity that this is written against.
+- `id` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+- `kind` (String) The high level entity type being described.
+- `metadata` (Attributes) Metadata fields common to all versions/kinds of entity. (see [below for nested schema](#nestedatt--fallback--metadata))
+- `namespace` (String) Namespace that the entity belongs to.
+- `relations` (Attributes List) Relations that this entity has with other entities (see [below for nested schema](#nestedatt--fallback--relations))
+- `spec` (Attributes) The specification data describing the entity itself. (see [below for nested schema](#nestedatt--fallback--spec))
+
+<a id="nestedatt--fallback--metadata"></a>
+### Nested Schema for `fallback.metadata`
+
+Optional:
+
+- `annotations` (Map of String) Key/Value pairs of non-identifying auxiliary information attached to entity.
+- `description` (String) A short (typically relatively few words) description of the entity.
+- `etag` (String) An opaque string that changes for each update operation to any part of the entity, including metadata. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.The field can (optionally) be specified when performing update or delete operations, and the server will then reject the operation if it does not match the current stored value.
+- `labels` (Map of String) Key/Value pairs of identifying information attached to the entity.
+- `links` (Attributes List) A list of external hyperlinks related to the entity. Links can provide additional contextual information that may be located outside of Backstage itself. For example, an admin dashboard or external CMS page. (see [below for nested schema](#nestedatt--fallback--metadata--links))
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the entity belongs to.
+- `tags` (List of String) A list of single-valued strings, to for example classify catalog entities in various ways.
+- `title` (String) A display name of the entity, to be presented in user interfaces instead of the name property, when available.
+- `uid` (String) A globally unique ID for the entity. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.
+
+<a id="nestedatt--fallback--metadata--links"></a>
+### Nested Schema for `fallback.metadata.links`
+
+Optional:
+
+- `icon` (String) A key representing a visual icon to be displayed in the UI.
+- `title` (String) A user-friendly display name for the link.
+- `type` (String) An optional value to categorize links into specific groups.
+- `url` (String) URL in a standard uri format.
+
+
+
+<a id="nestedatt--fallback--relations"></a>
+### Nested Schema for `fallback.relations`
+
+Optional:
+
+- `target` (Attributes) The entity of the target of this relation. (see [below for nested schema](#nestedatt--fallback--relations--target))
+- `target_ref` (String) The entity ref of the target of this relation.
+- `type` (String) Type of the relation.
+
+<a id="nestedatt--fallback--relations--target"></a>
+### Nested Schema for `fallback.relations.target`
+
+Optional:
+
+- `kind` (String) The high level entity type being described.
+- `name` (String) Name of the entity.
+- `namespace` (String) Namespace that the target entity belongs to.
+
+
+
+<a id="nestedatt--fallback--spec"></a>
+### Nested Schema for `fallback.spec`
+
+Optional:
+
+- `member_of` (List of String) The list of groups that the user is a direct member of (i.e., no transitive memberships are listed here).
+- `profile` (Attributes) Profile information about the user, mainly for display purposes. (see [below for nested schema](#nestedatt--fallback--spec--profile))
+
+<a id="nestedatt--fallback--spec--profile"></a>
+### Nested Schema for `fallback.spec.profile`
+
+Optional:
+
+- `display_name` (String) A simple display name to present to users.
+- `email` (String) Email where this user can be reached.
+- `picture` (String) A URL of an image that represents this user.
+
+
+
 
 <a id="nestedatt--metadata"></a>
 ### Nested Schema for `metadata`


### PR DESCRIPTION
This PR introduces the option to specify fallbacks for all current datasources.

A fallback is any Backstage resource in its entirety. For example, the fallback for the `System` will have the same input entity as the datasource.

The fallback for a particular datasource is supplied as an input variable for the datasource.

The fallback for a provided entity is only used when an error happens e.g. the backstage instance is down or the client was misconfigured or there's a proxy blocking connections suddenly.

Wrt Issue #160 