### PR TITLE
ci(test): update terraform versions in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,9 +82,9 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.7.*'
           - '1.8.*'
           - '1.9.*'
+          - '1.10.*'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0


### PR DESCRIPTION
Remove Terraform 1.7.* and add 1.10.* to keep up with latest releases.

This ensures we test against more recent versions of Terraform while maintaining compatibility with recent stable releases.