### PR TITLE
fix(tests): fix tests for `api` and `domain`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'go.mod'

--- a/backstage/data_source_api_test.go
+++ b/backstage/data_source_api_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceApi(t *testing.T) {
 					resource.TestCheckResourceAttr("data.backstage_api.test", "metadata.description",
 						"The Smartylighting Streetlights API allows you to remotely manage the city lights."),
 					resource.TestCheckResourceAttr("data.backstage_api.test", "metadata.tags.0", "mqtt"),
-					resource.TestCheckResourceAttr("data.backstage_api.test", "relations.0.target.name", "petstore"),
+					resource.TestCheckResourceAttr("data.backstage_api.test", "relations.0.target_ref", "component:default/petstore"),
 					resource.TestCheckResourceAttr("data.backstage_api.test", "spec.lifecycle", "production"),
 				),
 			},

--- a/backstage/data_source_domain_test.go
+++ b/backstage/data_source_domain_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceDomain(t *testing.T) {
 					resource.TestCheckResourceAttr("data.backstage_domain.test", "metadata.annotations.backstage.io/source-location",
 						"url:https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/domains/"),
 					resource.TestCheckResourceAttr("data.backstage_domain.test", "metadata.description", "Everything related to artists"),
-					resource.TestCheckResourceAttr("data.backstage_domain.test", "relations.0.target.name", "artist-engagement-portal"),
+					resource.TestCheckResourceAttr("data.backstage_domain.test", "relations.0.target_ref", "system:default/artist-engagement-portal"),
 					resource.TestCheckResourceAttr("data.backstage_domain.test", "spec.owner", "team-a"),
 				),
 			},


### PR DESCRIPTION
Something has changed in the instance we use for the integration tests, and the relations no longer contain target names (see [example](https://demo.backstage.io/api/catalog/entities/by-name/domain/default/artists)). Update the tests to compare with the `TargetRef` instead.