### PR TITLE
feat(ci): add support for for Terraform `1.11`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,11 +81,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.8.*'
           - '1.9.*'
           - '1.10.*'
+          - '1.11.*'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0


### PR DESCRIPTION
Remove support for Terraform 1.8.* and add support for 1.11.* in the test workflow